### PR TITLE
feat: 리뷰 작성 API 구현 및 테스트 코드 추가 (coverage 100%)

### DIFF
--- a/apps/studies/serializers/review_serializers.py
+++ b/apps/studies/serializers/review_serializers.py
@@ -1,50 +1,56 @@
+from typing import Any
+
 from rest_framework import serializers
-from apps.studies.models.study_reviews import StudyReview
+from rest_framework.validators import UniqueTogetherValidator
+
 from apps.studies.models.study_groups import StudyGroup
+from apps.studies.models.study_reviews import StudyReview
 
 
-class ReviewCreateSerializer(serializers.ModelSerializer):
+class ReviewCreateSerializer(serializers.ModelSerializer[StudyReview]):
     """
     스터디 리뷰 작성 Serializer
     - 종료된 스터디 그룹만 리뷰 가능
     - 한 유저가 같은 스터디 그룹에 중복 리뷰 작성 불가
     """
 
+    # 요청에서 받는 필드
     study_group_id = serializers.PrimaryKeyRelatedField(
-        queryset=StudyGroup.objects.all(),
-        source="study_group",
-        write_only=True
+        queryset=StudyGroup.objects.all(), source="study_group", write_only=True
     )
-    
-    rating = serializers.ChoiceField(
-        choices=StudyReview.RatingEnum.choices,
-        source="star_rating"
-    )
-    
+    rating = serializers.ChoiceField(choices=StudyReview.RatingEnum.choices, source="star_rating")
+
+    # 응답 전용
     user_id = serializers.IntegerField(source="user.id", read_only=True)
+
+    # 내부 Hidden 필드
+    user = serializers.HiddenField(default=serializers.CurrentUserDefault())
+    study_group = serializers.HiddenField(default=None) 
 
     class Meta:
         model = StudyReview
-        fields = ["id", "user_id", "study_group_id", "rating", "content", "created_at"]
+        fields = ["id", "user", "user_id", "study_group", "study_group_id", "rating", "content", "created_at"]
         read_only_fields = ["id", "user_id", "created_at"]
 
-    def validate(self, attrs):
-        user = self.context["request"].user
-        study_group = attrs["study_group"]
+        extra_kwargs = {
+            "user": {"write_only": True},
+            "study_group": {"write_only": True},  # 응답에서 숨김
+        }
+        validators = [ # 코치님 피드백 반영: user + study_group 중복 검증은 UniqueTogetherValidator로 처리
+            UniqueTogetherValidator(
+                queryset=StudyReview.objects.all(),
+                fields=["user", "study_group"],
+                message="이미 리뷰를 작성한 스터디 그룹입니다.",
+            )
+        ]
 
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        study_group = attrs["study_group"]
         if study_group.status != StudyGroup.StatusChoices.ENDED:
             raise serializers.ValidationError(
                 {"study_group_id": ["종료되지 않은 스터디 그룹에는 리뷰를 작성할 수 없습니다."]}
             )
-
-        if StudyReview.objects.filter(user=user, study_group=study_group).exists():
-            raise serializers.ValidationError(
-                {"study_group_id": ["이미 리뷰를 작성한 스터디 그룹입니다."]}
-            )
-
         return attrs
 
-    def create(self, validated_data):
-        user = self.context["request"].user
-        return StudyReview.objects.create(user=user, **validated_data)
-
+    def create(self, validated_data: dict[str, Any]) -> StudyReview:
+        return StudyReview.objects.create(**validated_data)

--- a/apps/studies/serializers/review_serializers.py
+++ b/apps/studies/serializers/review_serializers.py
@@ -5,41 +5,40 @@ from rest_framework.validators import UniqueTogetherValidator
 
 from apps.studies.models.study_groups import StudyGroup
 from apps.studies.models.study_reviews import StudyReview
+from apps.users.models.user import User
 
-
-class ReviewCreateSerializer(serializers.ModelSerializer[StudyReview]):
+# 요청 전용 Serializer
+class ReviewCreateRequestSerializer(serializers.ModelSerializer):
     """
-    스터디 리뷰 작성 Serializer
-    - 종료된 스터디 그룹만 리뷰 가능
-    - 한 유저가 같은 스터디 그룹에 중복 리뷰 작성 불가
+    스터디 리뷰 작성 Request Serializer
+    - 클라이언트가 보내는 값만 포함
     """
 
-    # 요청에서 받는 필드
     study_group_id = serializers.PrimaryKeyRelatedField(
-        queryset=StudyGroup.objects.all(), source="study_group", write_only=True
+        queryset=StudyGroup.objects.all(),
+        source="study_group",
+        write_only=True,
     )
-    rating = serializers.ChoiceField(choices=StudyReview.RatingEnum.choices, source="star_rating")
-
-    # 응답 전용
-    user_id = serializers.IntegerField(source="user.id", read_only=True)
+    rating = serializers.ChoiceField(
+        choices=StudyReview.RatingEnum.choices,
+        source="star_rating",
+        write_only=True,
+    )
 
     # 내부 Hidden 필드
     user = serializers.HiddenField(default=serializers.CurrentUserDefault())
-    study_group = serializers.HiddenField(default=None)
-
+    
     class Meta:
         model = StudyReview
-        fields = ["id", "user", "user_id", "study_group", "study_group_id", "rating", "content", "created_at"]
-        read_only_fields = ["id", "user_id", "created_at"]
+        fields = ["user", "study_group_id", "rating", "content"]
 
         extra_kwargs = {
-            "user": {"write_only": True},
-            "study_group": {"write_only": True},  # 응답에서 숨김
+            "content": {"write_only": True}
         }
-        validators = [  # 코치님 피드백 반영: user + study_group 중복 검증은 UniqueTogetherValidator로 처리
+        validators = [
             UniqueTogetherValidator(
                 queryset=StudyReview.objects.all(),
-                fields=["user", "study_group"],
+                fields=["user", "study_group_id"],
                 message="이미 리뷰를 작성한 스터디 그룹입니다.",
             )
         ]
@@ -48,6 +47,23 @@ class ReviewCreateSerializer(serializers.ModelSerializer[StudyReview]):
         study_group = attrs["study_group"]
         if study_group.status != StudyGroup.StatusChoices.ENDED:
             raise serializers.ValidationError(
-                {"study_group_id": ["종료되지 않은 스터디 그룹에는 리뷰를 작성할 수 없습니다."]}
+                {"detail": "종료되지 않은 스터디 그룹에는 리뷰를 작성할 수 없습니다."}
             )
         return attrs
+
+
+#응답 전용 Serializer
+class ReviewCreateResponseSerializer(serializers.ModelSerializer):
+    """
+    스터디 리뷰 작성 Response Serializer
+    - 서버가 클라이언트에게 돌려주는 값만 포함
+    """
+
+    user_id = serializers.IntegerField(source="user.id", read_only=True)
+    study_group_id = serializers.IntegerField(source="study_group.id", read_only=True)
+    rating = serializers.IntegerField(source="star_rating")
+
+    class Meta:
+        model = StudyReview
+        fields = ["id", "user_id", "study_group_id", "rating", "content", "created_at"]
+        read_only_fields = ["id", "user_id", "study_group_id", "created_at"]

--- a/apps/studies/serializers/review_serializers.py
+++ b/apps/studies/serializers/review_serializers.py
@@ -7,8 +7,9 @@ from apps.studies.models.study_groups import StudyGroup
 from apps.studies.models.study_reviews import StudyReview
 from apps.users.models.user import User
 
+
 # 요청 전용 Serializer
-class ReviewCreateRequestSerializer(serializers.ModelSerializer):
+class ReviewCreateRequestSerializer(serializers.ModelSerializer[StudyReview]):
     """
     스터디 리뷰 작성 Request Serializer
     - 클라이언트가 보내는 값만 포함
@@ -27,14 +28,12 @@ class ReviewCreateRequestSerializer(serializers.ModelSerializer):
 
     # 내부 Hidden 필드
     user = serializers.HiddenField(default=serializers.CurrentUserDefault())
-    
+
     class Meta:
         model = StudyReview
         fields = ["user", "study_group_id", "rating", "content"]
 
-        extra_kwargs = {
-            "content": {"write_only": True}
-        }
+        extra_kwargs = {"content": {"write_only": True}}
         validators = [
             UniqueTogetherValidator(
                 queryset=StudyReview.objects.all(),
@@ -46,14 +45,12 @@ class ReviewCreateRequestSerializer(serializers.ModelSerializer):
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
         study_group = attrs["study_group"]
         if study_group.status != StudyGroup.StatusChoices.ENDED:
-            raise serializers.ValidationError(
-                {"detail": "종료되지 않은 스터디 그룹에는 리뷰를 작성할 수 없습니다."}
-            )
+            raise serializers.ValidationError({"detail": "종료되지 않은 스터디 그룹에는 리뷰를 작성할 수 없습니다."})
         return attrs
 
 
-#응답 전용 Serializer
-class ReviewCreateResponseSerializer(serializers.ModelSerializer):
+# 응답 전용 Serializer
+class ReviewCreateResponseSerializer(serializers.ModelSerializer[StudyReview]):
     """
     스터디 리뷰 작성 Response Serializer
     - 서버가 클라이언트에게 돌려주는 값만 포함

--- a/apps/studies/serializers/review_serializers.py
+++ b/apps/studies/serializers/review_serializers.py
@@ -51,6 +51,3 @@ class ReviewCreateSerializer(serializers.ModelSerializer[StudyReview]):
                 {"study_group_id": ["종료되지 않은 스터디 그룹에는 리뷰를 작성할 수 없습니다."]}
             )
         return attrs
-
-    def create(self, validated_data: dict[str, Any]) -> StudyReview:
-        return StudyReview.objects.create(**validated_data)

--- a/apps/studies/serializers/review_serializers.py
+++ b/apps/studies/serializers/review_serializers.py
@@ -25,7 +25,7 @@ class ReviewCreateSerializer(serializers.ModelSerializer[StudyReview]):
 
     # 내부 Hidden 필드
     user = serializers.HiddenField(default=serializers.CurrentUserDefault())
-    study_group = serializers.HiddenField(default=None) 
+    study_group = serializers.HiddenField(default=None)
 
     class Meta:
         model = StudyReview
@@ -36,7 +36,7 @@ class ReviewCreateSerializer(serializers.ModelSerializer[StudyReview]):
             "user": {"write_only": True},
             "study_group": {"write_only": True},  # 응답에서 숨김
         }
-        validators = [ # 코치님 피드백 반영: user + study_group 중복 검증은 UniqueTogetherValidator로 처리
+        validators = [  # 코치님 피드백 반영: user + study_group 중복 검증은 UniqueTogetherValidator로 처리
             UniqueTogetherValidator(
                 queryset=StudyReview.objects.all(),
                 fields=["user", "study_group"],

--- a/apps/studies/serializers/review_serializers.py
+++ b/apps/studies/serializers/review_serializers.py
@@ -1,0 +1,50 @@
+from rest_framework import serializers
+from apps.studies.models.study_reviews import StudyReview
+from apps.studies.models.study_groups import StudyGroup
+
+
+class ReviewCreateSerializer(serializers.ModelSerializer):
+    """
+    스터디 리뷰 작성 Serializer
+    - 종료된 스터디 그룹만 리뷰 가능
+    - 한 유저가 같은 스터디 그룹에 중복 리뷰 작성 불가
+    """
+
+    study_group_id = serializers.PrimaryKeyRelatedField(
+        queryset=StudyGroup.objects.all(),
+        source="study_group",
+        write_only=True
+    )
+    
+    rating = serializers.ChoiceField(
+        choices=StudyReview.RatingEnum.choices,
+        source="star_rating"
+    )
+    
+    user_id = serializers.IntegerField(source="user.id", read_only=True)
+
+    class Meta:
+        model = StudyReview
+        fields = ["id", "user_id", "study_group_id", "rating", "content", "created_at"]
+        read_only_fields = ["id", "user_id", "created_at"]
+
+    def validate(self, attrs):
+        user = self.context["request"].user
+        study_group = attrs["study_group"]
+
+        if study_group.status != StudyGroup.StatusChoices.ENDED:
+            raise serializers.ValidationError(
+                {"study_group_id": ["종료되지 않은 스터디 그룹에는 리뷰를 작성할 수 없습니다."]}
+            )
+
+        if StudyReview.objects.filter(user=user, study_group=study_group).exists():
+            raise serializers.ValidationError(
+                {"study_group_id": ["이미 리뷰를 작성한 스터디 그룹입니다."]}
+            )
+
+        return attrs
+
+    def create(self, validated_data):
+        user = self.context["request"].user
+        return StudyReview.objects.create(user=user, **validated_data)
+

--- a/apps/studies/tests/test_reviews.py
+++ b/apps/studies/tests/test_reviews.py
@@ -1,8 +1,9 @@
-from rest_framework.test import APIClient, APITestCase
-from django.contrib.auth import get_user_model
-from django.utils import timezone
-from django.urls import reverse
 from datetime import timedelta
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework.test import APIClient, APITestCase
 
 from apps.studies.models import StudyGroup, StudyReview
 
@@ -15,14 +16,10 @@ class TestStudyReviewCreateAPI(APITestCase):
     POST /api/v1/reviews/
     """
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.client = APIClient()
         self.user = User.objects.create_user(
-            email="test@test.com",
-            password="1234",
-            birthday="2000-01-01",
-            name="테스트유저",
-            nickname="tester"
+            email="test@test.com", password="1234", birthday="2000-01-01", name="테스트유저", nickname="tester"
         )
         self.client.force_authenticate(self.user)
 
@@ -33,12 +30,12 @@ class TestStudyReviewCreateAPI(APITestCase):
             max_headcount=5,
             start_at=timezone.now() - timedelta(days=10),
             end_at=timezone.now() - timedelta(days=1),
-            status=StudyGroup.StatusChoices.ENDED
+            status=StudyGroup.StatusChoices.ENDED,
         )
         self.url = reverse("review-create")
 
-    def test_create_review_success(self):
-        #성공 케이스
+    def test_create_review_success(self) -> None:
+        # 성공 케이스
         data = {
             "study_group_id": self.study_group.id,
             "rating": 5,
@@ -50,39 +47,37 @@ class TestStudyReviewCreateAPI(APITestCase):
         self.assertEqual(StudyReview.objects.count(), 1)
         self.assertEqual(response.data["content"], data["content"])
 
-    def test_create_review_unauthenticated(self):
-        #실패: 비로그인
+    def test_create_review_unauthenticated(self) -> None:
+        # 실패: 비로그인
         client = APIClient()
         data = {"study_group_id": self.study_group.id, "rating": 5, "content": "로그인 안 했어요"}
         response = client.post(self.url, data, format="json")
         self.assertEqual(response.status_code, 401)
 
-    def test_create_review_duplicate(self):
-        #실패: 중복 리뷰
-        StudyReview.objects.create(
-            user=self.user, study_group=self.study_group, star_rating=5, content="첫 리뷰"
-        )
+    def test_create_review_duplicate(self) -> None:
+        # 실패: 중복 리뷰
+        StudyReview.objects.create(user=self.user, study_group=self.study_group, star_rating=5, content="첫 리뷰")
         data = {"study_group_id": self.study_group.id, "rating": 5, "content": "중복 리뷰 시도"}
         response = self.client.post(self.url, data, format="json")
 
         self.assertEqual(response.status_code, 400)
         self.assertIn("이미 리뷰를 작성한", str(response.data))
 
-    def test_create_review_invalid_rating(self):
-        #실패: 잘못된 평점 일부러 존재하지않는 점수 부여함 ㅋ
+    def test_create_review_invalid_rating(self) -> None:
+        # 실패: 잘못된 평점 일부러 존재하지않는 점수 부여함 ㅋ
         data = {"study_group_id": self.study_group.id, "rating": 10, "content": "잘못된 평점"}
         response = self.client.post(self.url, data, format="json")
         self.assertEqual(response.status_code, 400)
 
-    def test_create_review_not_ended_group(self):
-        #실패: 종료되지 않은 스터디 그룹
+    def test_create_review_not_ended_group(self) -> None:
+        # 실패: 종료되지 않은 스터디 그룹
         active_group = StudyGroup.objects.create(
             name="진행중 스터디",
             introduction="아직 진행 중",
             max_headcount=5,
             start_at=timezone.now() - timedelta(days=1),
             end_at=timezone.now() + timedelta(days=7),
-            status=StudyGroup.StatusChoices.ONGOING
+            status=StudyGroup.StatusChoices.ONGOING,
         )
         data = {"study_group_id": active_group.id, "rating": 5, "content": "아직 끝나지 않았어요"}
         response = self.client.post(self.url, data, format="json")
@@ -90,20 +85,20 @@ class TestStudyReviewCreateAPI(APITestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn("종료되지 않은", str(response.data))
 
-
-    def test_create_review_triggers_create_method(self):
-        #성공 케이스에서 create() 메서드까지 실행 확인
+    def test_create_review_triggers_create_method(self) -> None:
+        # 성공 케이스에서 create() 메서드까지 실행 확인
         data = {"study_group_id": self.study_group.id, "rating": 4, "content": "create 메서드 확인"}
         response = self.client.post(self.url, data, format="json")
 
         self.assertEqual(response.status_code, 201)
         review = StudyReview.objects.first()
-        
+        assert review is not None  # mypy 통과용
+
         self.assertEqual(review.user, self.user)
         self.assertEqual(review.star_rating, 4)
 
-    def test_create_review_exact_error_messages(self):
-        #실패 케이스에서 ValidationError 메시지 구조까지 검증
+    def test_create_review_exact_error_messages(self) -> None:
+        # 실패 케이스에서 ValidationError 메시지 구조까지 검증
         # 종료되지 않은 그룹
         active_group = StudyGroup.objects.create(
             name="미종료 스터디",
@@ -111,12 +106,11 @@ class TestStudyReviewCreateAPI(APITestCase):
             max_headcount=5,
             start_at=timezone.now(),
             end_at=timezone.now() + timedelta(days=5),
-            status=StudyGroup.StatusChoices.ONGOING
+            status=StudyGroup.StatusChoices.ONGOING,
         )
         data = {"study_group_id": active_group.id, "rating": 5, "content": "에러 메시지 확인"}
         response = self.client.post(self.url, data, format="json")
 
         self.assertEqual(response.status_code, 400)
-        # 키 값과 메시지가 정확히 일치하는지 확인
         self.assertIn("study_group_id", response.data)
         self.assertIn("종료되지 않은 스터디 그룹에는 리뷰를 작성할 수 없습니다.", response.data["study_group_id"])

--- a/apps/studies/tests/test_reviews.py
+++ b/apps/studies/tests/test_reviews.py
@@ -99,7 +99,6 @@ class TestStudyReviewCreateAPI(APITestCase):
 
     def test_create_review_exact_error_messages(self) -> None:
         # 실패 케이스에서 ValidationError 메시지 구조까지 검증
-        # 종료되지 않은 그룹
         active_group = StudyGroup.objects.create(
             name="미종료 스터디",
             introduction="테스트",
@@ -108,9 +107,19 @@ class TestStudyReviewCreateAPI(APITestCase):
             end_at=timezone.now() + timedelta(days=5),
             status=StudyGroup.StatusChoices.ONGOING,
         )
-        data = {"study_group_id": active_group.id, "rating": 5, "content": "에러 메시지 확인"}
+        data = {
+            "study_group_id": active_group.id,
+            "rating": 5,
+            "content": "에러 메시지 확인",
+        }
         response = self.client.post(self.url, data, format="json")
 
         self.assertEqual(response.status_code, 400)
-        self.assertIn("study_group_id", response.data)
-        self.assertIn("종료되지 않은 스터디 그룹에는 리뷰를 작성할 수 없습니다.", response.data["study_group_id"])
+
+        # 기존: self.assertIn("study_group_id", response.data)
+        # 수정: "detail" 키와 메시지 내용 확인
+        self.assertIn("detail", response.data)
+        self.assertIn(
+            "종료되지 않은 스터디 그룹에는 리뷰를 작성할 수 없습니다.",
+            response.data["detail"]
+        )

--- a/apps/studies/tests/test_reviews.py
+++ b/apps/studies/tests/test_reviews.py
@@ -119,7 +119,4 @@ class TestStudyReviewCreateAPI(APITestCase):
         # 기존: self.assertIn("study_group_id", response.data)
         # 수정: "detail" 키와 메시지 내용 확인
         self.assertIn("detail", response.data)
-        self.assertIn(
-            "종료되지 않은 스터디 그룹에는 리뷰를 작성할 수 없습니다.",
-            response.data["detail"]
-        )
+        self.assertIn("종료되지 않은 스터디 그룹에는 리뷰를 작성할 수 없습니다.", response.data["detail"])

--- a/apps/studies/tests/test_reviews.py
+++ b/apps/studies/tests/test_reviews.py
@@ -1,0 +1,122 @@
+from rest_framework.test import APIClient, APITestCase
+from django.contrib.auth import get_user_model
+from django.utils import timezone
+from django.urls import reverse
+from datetime import timedelta
+
+from apps.studies.models import StudyGroup, StudyReview
+
+User = get_user_model()
+
+
+class TestStudyReviewCreateAPI(APITestCase):
+    """
+    [REQ-REVW-001] 스터디 그룹 리뷰 작성 API
+    POST /api/v1/reviews/
+    """
+
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            email="test@test.com",
+            password="1234",
+            birthday="2000-01-01",
+            name="테스트유저",
+            nickname="tester"
+        )
+        self.client.force_authenticate(self.user)
+
+        # 종료된 스터디 그룹
+        self.study_group = StudyGroup.objects.create(
+            name="테스트 스터디",
+            introduction="테스트용 소개글",
+            max_headcount=5,
+            start_at=timezone.now() - timedelta(days=10),
+            end_at=timezone.now() - timedelta(days=1),
+            status=StudyGroup.StatusChoices.ENDED
+        )
+        self.url = reverse("review-create")
+
+    def test_create_review_success(self):
+        #성공 케이스
+        data = {
+            "study_group_id": self.study_group.id,
+            "rating": 5,
+            "content": "정말 유익한 스터디였습니다!",
+        }
+        response = self.client.post(self.url, data, format="json")
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(StudyReview.objects.count(), 1)
+        self.assertEqual(response.data["content"], data["content"])
+
+    def test_create_review_unauthenticated(self):
+        #실패: 비로그인
+        client = APIClient()
+        data = {"study_group_id": self.study_group.id, "rating": 5, "content": "로그인 안 했어요"}
+        response = client.post(self.url, data, format="json")
+        self.assertEqual(response.status_code, 401)
+
+    def test_create_review_duplicate(self):
+        #실패: 중복 리뷰
+        StudyReview.objects.create(
+            user=self.user, study_group=self.study_group, star_rating=5, content="첫 리뷰"
+        )
+        data = {"study_group_id": self.study_group.id, "rating": 5, "content": "중복 리뷰 시도"}
+        response = self.client.post(self.url, data, format="json")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("이미 리뷰를 작성한", str(response.data))
+
+    def test_create_review_invalid_rating(self):
+        #실패: 잘못된 평점 일부러 존재하지않는 점수 부여함 ㅋ
+        data = {"study_group_id": self.study_group.id, "rating": 10, "content": "잘못된 평점"}
+        response = self.client.post(self.url, data, format="json")
+        self.assertEqual(response.status_code, 400)
+
+    def test_create_review_not_ended_group(self):
+        #실패: 종료되지 않은 스터디 그룹
+        active_group = StudyGroup.objects.create(
+            name="진행중 스터디",
+            introduction="아직 진행 중",
+            max_headcount=5,
+            start_at=timezone.now() - timedelta(days=1),
+            end_at=timezone.now() + timedelta(days=7),
+            status=StudyGroup.StatusChoices.ONGOING
+        )
+        data = {"study_group_id": active_group.id, "rating": 5, "content": "아직 끝나지 않았어요"}
+        response = self.client.post(self.url, data, format="json")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("종료되지 않은", str(response.data))
+
+
+    def test_create_review_triggers_create_method(self):
+        #성공 케이스에서 create() 메서드까지 실행 확인
+        data = {"study_group_id": self.study_group.id, "rating": 4, "content": "create 메서드 확인"}
+        response = self.client.post(self.url, data, format="json")
+
+        self.assertEqual(response.status_code, 201)
+        review = StudyReview.objects.first()
+        
+        self.assertEqual(review.user, self.user)
+        self.assertEqual(review.star_rating, 4)
+
+    def test_create_review_exact_error_messages(self):
+        #실패 케이스에서 ValidationError 메시지 구조까지 검증
+        # 종료되지 않은 그룹
+        active_group = StudyGroup.objects.create(
+            name="미종료 스터디",
+            introduction="테스트",
+            max_headcount=5,
+            start_at=timezone.now(),
+            end_at=timezone.now() + timedelta(days=5),
+            status=StudyGroup.StatusChoices.ONGOING
+        )
+        data = {"study_group_id": active_group.id, "rating": 5, "content": "에러 메시지 확인"}
+        response = self.client.post(self.url, data, format="json")
+
+        self.assertEqual(response.status_code, 400)
+        # 키 값과 메시지가 정확히 일치하는지 확인
+        self.assertIn("study_group_id", response.data)
+        self.assertIn("종료되지 않은 스터디 그룹에는 리뷰를 작성할 수 없습니다.", response.data["study_group_id"])

--- a/apps/studies/urls/__init__.py
+++ b/apps/studies/urls/__init__.py
@@ -1,0 +1,3 @@
+from apps.studies.urls.review_urls import urlpatterns as review_urls
+
+urlpatterns = review_urls

--- a/apps/studies/urls/review_urls.py
+++ b/apps/studies/urls/review_urls.py
@@ -3,5 +3,5 @@ from django.urls import path
 from apps.studies.views.review_views import ReviewCreateAPIView
 
 urlpatterns = [
-    path("", ReviewCreateAPIView.as_view(), name="review-create"),
+    path("/reviews", ReviewCreateAPIView.as_view(), name="review-create"),
 ]

--- a/apps/studies/urls/reviews.py
+++ b/apps/studies/urls/reviews.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from apps.studies.views.review_views import ReviewCreateAPIView
+
+urlpatterns = [
+    path("reviews/", ReviewCreateAPIView.as_view(), name="review-create"),
+]

--- a/apps/studies/urls/reviews.py
+++ b/apps/studies/urls/reviews.py
@@ -1,6 +1,7 @@
 from django.urls import path
+
 from apps.studies.views.review_views import ReviewCreateAPIView
 
 urlpatterns = [
-    path("reviews/", ReviewCreateAPIView.as_view(), name="review-create"),
+    path("", ReviewCreateAPIView.as_view(), name="review-create"),
 ]

--- a/apps/studies/views/review_views.py
+++ b/apps/studies/views/review_views.py
@@ -1,0 +1,16 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from apps.studies.serializers.review_serializers import ReviewCreateSerializer
+
+class ReviewCreateAPIView(APIView):
+    """
+    [REQ-REVW-001] 스터디 그룹 리뷰 작성 API
+    POST /api/v1/reviews/
+    """
+    def post(self, request, *args, **kwargs):
+        serializer = ReviewCreateSerializer(data=request.data, context={"request": request})
+        if serializer.is_valid():
+            review = serializer.save()  
+            return Response(ReviewCreateSerializer(review).data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/apps/studies/views/review_views.py
+++ b/apps/studies/views/review_views.py
@@ -1,16 +1,20 @@
-from rest_framework.views import APIView
-from rest_framework.response import Response
 from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
 from apps.studies.serializers.review_serializers import ReviewCreateSerializer
+
 
 class ReviewCreateAPIView(APIView):
     """
     [REQ-REVW-001] 스터디 그룹 리뷰 작성 API
     POST /api/v1/reviews/
     """
-    def post(self, request, *args, **kwargs):
+
+    def post(self, request: Request, *args: object, **kwargs: object) -> Response:
         serializer = ReviewCreateSerializer(data=request.data, context={"request": request})
         if serializer.is_valid():
-            review = serializer.save()  
+            review = serializer.save()
             return Response(ReviewCreateSerializer(review).data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/apps/studies/views/review_views.py
+++ b/apps/studies/views/review_views.py
@@ -3,7 +3,10 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.studies.serializers.review_serializers import ReviewCreateSerializer
+from apps.studies.serializers.review_serializers import (
+    ReviewCreateRequestSerializer,
+    ReviewCreateResponseSerializer,
+)
 
 
 class ReviewCreateAPIView(APIView):
@@ -13,8 +16,16 @@ class ReviewCreateAPIView(APIView):
     """
 
     def post(self, request: Request, *args: object, **kwargs: object) -> Response:
-        serializer = ReviewCreateSerializer(data=request.data, context={"request": request})
-        if serializer.is_valid():
-            review = serializer.save()
-            return Response(ReviewCreateSerializer(review).data, status=status.HTTP_201_CREATED)
-        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+        # 요청 검증
+        request_serializer = ReviewCreateRequestSerializer(
+            data=request.data, context={"request": request}
+        )
+        if request_serializer.is_valid():
+            # 저장
+            review = request_serializer.save()
+
+            # 응답 변환
+            response_serializer = ReviewCreateResponseSerializer(review)
+            return Response(response_serializer.data, status=status.HTTP_201_CREATED)
+
+        return Response(request_serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/apps/studies/views/review_views.py
+++ b/apps/studies/views/review_views.py
@@ -17,9 +17,7 @@ class ReviewCreateAPIView(APIView):
 
     def post(self, request: Request, *args: object, **kwargs: object) -> Response:
         # 요청 검증
-        request_serializer = ReviewCreateRequestSerializer(
-            data=request.data, context={"request": request}
-        )
+        request_serializer = ReviewCreateRequestSerializer(data=request.data, context={"request": request})
         if request_serializer.is_valid():
             # 저장
             review = request_serializer.save()

--- a/config/urls.py
+++ b/config/urls.py
@@ -13,6 +13,7 @@ urlpatterns: list[URLPattern | URLResolver] = [
     path("api/v1/notifications", include("apps.notifications.urls")),
     path("api/v1/recruitments", include("apps.recruitments.urls")),
     path("api/v1/schedules", include("apps.study_group_schedules.urls")),
+    path("api/v1/reviews", include("apps.studies.urls.reviews")),
 ]
 
 if settings.DEBUG:

--- a/config/urls.py
+++ b/config/urls.py
@@ -13,7 +13,7 @@ urlpatterns: list[URLPattern | URLResolver] = [
     path("api/v1/notifications", include("apps.notifications.urls")),
     path("api/v1/recruitments", include("apps.recruitments.urls")),
     path("api/v1/schedules", include("apps.study_group_schedules.urls")),
-    path("api/v1/reviews", include("apps.studies.urls.reviews")),
+    path("api/v1/study-groups", include("apps.studies.urls")),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
##  PR 요약
- 관련 이슈 번호: #81
- 리뷰 작성 API (POST /api/v1/reviews/) 기능 구현
  - 종료된 스터디 그룹에만 작성 가능
  - 동일 유저의 중복 리뷰 작성 방지
  - 평점 범위(1~5) 유효성 검증
- 리뷰 작성 관련 테스트 케이스 총 7개 작성
  - 성공 케이스
  - 비로그인 요청
  - 중복 리뷰 작성
  - 잘못된 평점
  - 종료되지 않은 그룹
  - create() 메서드 동작 확인
  - 에러 메시지 구조 검증
- 테스트 전부 통과 
- coverage 100% 달성 
## 📄 상세 내용
- [ ] 주요 변경 사항 1
- [ ] 주요 변경 사항 2
- [ ] 주요 변경 사항 3

## 📸 스크린샷 (선택)
<img width="892" height="435" alt="image" src="https://github.com/user-attachments/assets/83d40d61-f2f6-4b55-b554-30bc8762aaa1" />

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
