### PR TITLE
✨ feat: 특정 알림 읽음 api 작성

### DIFF
--- a/apps/notifications/managers.py
+++ b/apps/notifications/managers.py
@@ -8,21 +8,5 @@ if TYPE_CHECKING:
 
 
 class NotificationManager(models.Manager["Notification"]):
-    def list_queryset(self, user_id: int, status: str) -> QuerySet["Notification"]:
-        qs = (
-            self.get_queryset()
-            .filter(user_id=user_id)
-            .only("id", "content", "notification_type", "is_read", "back_url_link", "created_at")
-        )
-
-        if status == "unread":
-            qs = qs.filter(is_read=False)
-        elif status == "read":
-            qs = qs.filter(is_read=True)
-
-        return qs
-
-    def read_only_one_queryset(self, notification_id: int, user_id: int | None) -> int:
-        if user_id is None:
-            return 0
-        return self.get_queryset().filter(id=notification_id, user_id=user_id).update(is_read=True)
+    def get_list_by_user_id_and_is_read(self, user_id: int, is_read: bool) -> QuerySet["Notification"]:
+        return self.get_queryset().filter(user_id=user_id, is_read=is_read)

--- a/apps/notifications/managers.py
+++ b/apps/notifications/managers.py
@@ -21,3 +21,8 @@ class NotificationManager(models.Manager["Notification"]):
             qs = qs.filter(is_read=True)
 
         return qs
+
+    def read_only_one_queryset(self, notification_id: int, user_id: int | None) -> int:
+        if user_id is None:
+            return 0
+        return self.get_queryset().filter(id=notification_id, user_id=user_id).update(is_read=True)

--- a/apps/notifications/serializers.py
+++ b/apps/notifications/serializers.py
@@ -43,9 +43,12 @@ class UnreadCountSerializer(serializers.Serializer[UnreadCountOut]):
 
 class NotificationListSerializer(serializers.Serializer[Any]):
     is_read = serializers.BooleanField(required=False)
+    type = serializers.ChoiceField(choices=Notification.NotificationType.choices, required=False)
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
-        # 쿼리스트링에 'is_read' 키 자체가 없었다면, 검증 결과에서도 제거
+        # 쿼리스트링에 밑의 키 자체가 없었다면, 검증 결과에서도 제거
         if "is_read" not in self.initial_data:
             attrs.pop("is_read", None)
+        if "type" not in self.initial_data:
+            attrs.pop("type", None)
         return attrs

--- a/apps/notifications/serializers.py
+++ b/apps/notifications/serializers.py
@@ -54,4 +54,3 @@ class NotificationListQueryParamsSerializer(serializers.Serializer[Any]):
             return False
         else:
             raise serializers.ValidationError("is_read value is must be 'true' or 'false'.")
-

--- a/apps/notifications/serializers.py
+++ b/apps/notifications/serializers.py
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing import Any, TypedDict
 
 from rest_framework import serializers
 
@@ -39,3 +39,13 @@ class UnreadCountSerializer(serializers.Serializer[UnreadCountOut]):
     """
 
     unread_count = serializers.IntegerField()
+
+
+class NotificationListSerializer(serializers.Serializer[Any]):
+    is_read = serializers.BooleanField(required=False)
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        # 쿼리스트링에 'is_read' 키 자체가 없었다면, 검증 결과에서도 제거
+        if "is_read" not in self.initial_data:
+            attrs.pop("is_read", None)
+        return attrs

--- a/apps/notifications/serializers.py
+++ b/apps/notifications/serializers.py
@@ -1,11 +1,13 @@
 from typing import Any, TypedDict
 
+# def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+#     # 쿼리스트링에 밑의 키 자체가 없었다면, 검증 결과에서도 제거
 from rest_framework import serializers
 
 from apps.notifications.models import Notification
 
 
-class NotificationSerializer(serializers.ModelSerializer[Notification]):
+class NotificationListSerializer(serializers.ModelSerializer[Notification]):
     """
     알림 목록 조회를 위한 Serializer
     """
@@ -41,14 +43,15 @@ class UnreadCountSerializer(serializers.Serializer[UnreadCountOut]):
     unread_count = serializers.IntegerField()
 
 
-class NotificationListSerializer(serializers.Serializer[Any]):
-    is_read = serializers.BooleanField(required=False)
-    type = serializers.ChoiceField(choices=Notification.NotificationType.choices, required=False)
+class NotificationListQueryParamsSerializer(serializers.Serializer[Any]):
+    is_read = serializers.CharField(required=False)
+    n_type = serializers.ChoiceField(choices=Notification.NotificationType.choices, required=False)
 
-    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
-        # 쿼리스트링에 밑의 키 자체가 없었다면, 검증 결과에서도 제거
-        if "is_read" not in self.initial_data:
-            attrs.pop("is_read", None)
-        if "type" not in self.initial_data:
-            attrs.pop("type", None)
-        return attrs
+    def validate_is_read(self, value: str) -> bool:
+        if value.lower() == "true":
+            return True
+        elif value.lower() == "false":
+            return False
+        else:
+            raise serializers.ValidationError("is_read value is must be 'true' or 'false'.")
+

--- a/apps/notifications/services/read_service.py
+++ b/apps/notifications/services/read_service.py
@@ -10,11 +10,17 @@ from apps.notifications.models import Notification
 class NotificationService:
     # 서비스에서는 Repository(Model Manager or 쿼리셋) 호출하여 비즈니스 로직 구성
     @classmethod
-    def get_notifications_list(cls, *, user_id: int, is_read: Optional[bool] = None) -> QuerySet[Notification]:
+    def get_notifications_list(
+        cls, *, user_id: int, is_read: Optional[bool] = None, notification_type: str
+    ) -> QuerySet[Notification]:
         if is_read is None:
-            return Notification.objects.filter(user_id=user_id)
+            list = Notification.objects.filter(user_id=user_id)
+        else:
+            list = Notification.objects.get_list_by_user_id_and_is_read(user_id=user_id, is_read=is_read)
+        if notification_type is not None:
+            list = list.filter(notification_type=notification_type)
 
-        return Notification.objects.get_list_by_user_id_and_is_read(user_id=user_id, is_read=is_read)
+        return list
 
     @classmethod
     @transaction.atomic

--- a/apps/notifications/services/read_service.py
+++ b/apps/notifications/services/read_service.py
@@ -11,16 +11,16 @@ class NotificationService:
     # 서비스에서는 Repository(Model Manager or 쿼리셋) 호출하여 비즈니스 로직 구성
     @classmethod
     def get_notifications_list(
-        cls, *, user_id: int, is_read: Optional[bool] = None, notification_type: str
+        cls, user_id: int, is_read: Optional[bool] = None, n_type: Optional[str] = None
     ) -> QuerySet[Notification]:
         if is_read is None:
-            list = Notification.objects.filter(user_id=user_id)
+            n_list = Notification.objects.filter(user_id=user_id)
         else:
-            list = Notification.objects.get_list_by_user_id_and_is_read(user_id=user_id, is_read=is_read)
-        if notification_type is not None:
-            list = list.filter(notification_type=notification_type)
+            n_list = Notification.objects.get_list_by_user_id_and_is_read(user_id=user_id, is_read=is_read)
+        if n_type is not None:
+            n_list = n_list.filter(notification_type=n_type)
 
-        return list
+        return n_list
 
     @classmethod
     @transaction.atomic

--- a/apps/notifications/services/read_service.py
+++ b/apps/notifications/services/read_service.py
@@ -1,0 +1,33 @@
+from typing import Optional
+
+from django.db import transaction
+from django.db.models import QuerySet
+from rest_framework.exceptions import NotFound
+
+from apps.notifications.models import Notification
+
+
+class NotificationService:
+    # 서비스에서는 Repository(Model Manager or 쿼리셋) 호출하여 비즈니스 로직 구성
+    @classmethod
+    def get_notifications_list(cls, *, user_id: int, is_read: Optional[bool] = None) -> QuerySet[Notification]:
+        if is_read is None:
+            return Notification.objects.filter(user_id=user_id)
+
+        return Notification.objects.get_list_by_user_id_and_is_read(user_id=user_id, is_read=is_read)
+
+    @classmethod
+    @transaction.atomic
+    def read_notification(cls, notification_id: int, user_id: int) -> None:
+        try:
+            notification = Notification.objects.get(id=notification_id, user_id=user_id)
+        except Notification.DoesNotExist:
+            raise NotFound
+        notification.is_read = True
+        notification.save()  # 하나의 알림만 수정하기 때문
+
+    @classmethod
+    @transaction.atomic
+    def read_all_user_notifications(cls, user_id: int) -> int:
+        notifications = Notification.objects.get_list_by_user_id_and_is_read(user_id=user_id, is_read=False)
+        return notifications.update(is_read=True)

--- a/apps/notifications/tests.py
+++ b/apps/notifications/tests.py
@@ -25,7 +25,7 @@ class NotificationViewsTests(APITestCase):
 
         now = timezone.now()
 
-        Notification.objects.bulk_create(
+        notis = Notification.objects.bulk_create(
             [
                 Notification(
                     user=self.user,
@@ -53,7 +53,7 @@ class NotificationViewsTests(APITestCase):
                 ),
             ]
         )
-
+        self.notification = notis[0]  # 첫번째 알람을 테스트 대상으로함 / self.notification 속성 정의를 위함(119)
         self.url = reverse("notifications:notification-list")
 
     def test_list_pagination(self) -> None:
@@ -116,11 +116,12 @@ class NotificationViewsTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_read_api_for_only_one_notification(self) -> None:
-        url = reverse("notifications:notification-read", kwargs={"notification_id": 1})
+        url = reverse("notifications:notification-read", kwargs={"notification_id": self.notification.id})
         response = self.client.post(url)
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(response.content, b"")  # 204 노컨텐츠이기에 빈 문자열
+        self.assertTrue(self.notification.is_read)
 
     def test_read_api_for_all_notification(self) -> None:
         url = reverse("notifications:notification-read-all")

--- a/apps/notifications/tests/test_notication_apis.py
+++ b/apps/notifications/tests/test_notication_apis.py
@@ -140,3 +140,11 @@ class NotificationViewsTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("unread_count", response.data)  # unread_count 키값이 있는지 확인
         self.assertIsInstance(response.data["unread_count"], int)  # unread_count가 int면 통과
+
+    def test_filter_by_type(self) -> None:
+        response = self.client.get(self.url, {"limit": 10, "offset": 0})
+        self.assertEqual(response.status_code, 200)
+        results = response.data["results"]
+        self.assertGreaterEqual(len(results), 2)
+        self.assertEqual(results[1]["type"], "ADD_APPLICATION")
+        self.assertEqual(results[1]["content"], "2")

--- a/apps/notifications/tests/test_notication_apis.py
+++ b/apps/notifications/tests/test_notication_apis.py
@@ -97,14 +97,14 @@ class NotificationViewsTests(APITestCase):
         self.assertEqual(len(response2.data["results"]), 1)
 
     def test_get_read_notification_list(self) -> None:
-        response = self.client.get(self.url, {"status": "read", "limit": "10", "offset": "0"})
+        response = self.client.get(self.url, {"is_read": "true", "limit": "10", "offset": "0"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
         for item in response.data["results"]:
             self.assertTrue(item["is_read"])
 
     def test_get_unread_notification_list(self) -> None:
-        response = self.client.get(self.url, {"status": "unread", "limit": "10", "offset": "0"})
+        response = self.client.get(self.url, {"is_read": "false", "limit": "10", "offset": "0"})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 2)
         for item in response.data["results"]:
@@ -121,6 +121,7 @@ class NotificationViewsTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(response.content, b"")  # 204 노컨텐츠이기에 빈 문자열
+        self.notification.refresh_from_db()  # 서비스에서 save() 호출 시 실제로 바뀌는지 확인하는 테스트
         self.assertTrue(self.notification.is_read)
 
     def test_read_api_for_all_notification(self) -> None:
@@ -129,6 +130,8 @@ class NotificationViewsTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(response.content, b"")
+        unread_exists = Notification.objects.filter(user=self.user, is_read=False).exists()
+        self.assertFalse(unread_exists)  # 전체 읽음 후 미읽음 개수가 0개인지 확인
 
     def test_unread_count(self) -> None:
         url = reverse("notifications:notification-unread-count")

--- a/apps/notifications/views.py
+++ b/apps/notifications/views.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from django.db import transaction
 from django.db.models import QuerySet
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
@@ -59,7 +60,13 @@ class NotificationUpdateView(APIView):
     특정 알림 읽음 처리
     """
 
+    permission_classes = [IsAuthenticated]
+
+    @transaction.atomic
     def post(self, request: Request, notification_id: int, *args: Any, **kwargs: Any) -> Response:
+        update = Notification.objects.read_only_one_queryset(notification_id=notification_id, user_id=request.user.pk)
+        if update == 0:
+            return Response({"detail": "Notification not found or access denied."}, status=status.HTTP_404_NOT_FOUND)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/apps/notifications/views.py
+++ b/apps/notifications/views.py
@@ -12,8 +12,8 @@ from rest_framework.views import APIView
 from apps.notifications.models import Notification
 from apps.notifications.pagination import NotificationLimitOffsetPagination
 from apps.notifications.serializers import (
+    NotificationListQueryParamsSerializer,
     NotificationListSerializer,
-    NotificationSerializer,
     NotificationUpdateSerializer,
     UnreadCountOut,
     UnreadCountSerializer,
@@ -26,29 +26,31 @@ from apps.users.models.user import User
     tags=["Notifications"],
     summary="알림 목록 조회 API",
     description="로그인한 유저의 알림 내역을 페이지네이션으로 조회. status로 필터링",
-    responses={200: NotificationSerializer(many=True)},
+    responses={200: NotificationListSerializer(many=True)},
 )
 class NotificationListView(ListAPIView[Notification]):
     """
     알림 목록 조회 with offset
     """
 
-    serializer_class: type[NotificationSerializer] = NotificationSerializer
+    serializer_class: type[NotificationListSerializer] = NotificationListSerializer
     pagination_class = NotificationLimitOffsetPagination
     permission_classes = [IsAuthenticated]
+    validated_query_params: dict[str, Any]
+
+    def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        # 쿼리파라미터 검증
+        qp = NotificationListQueryParamsSerializer(data=self.request.query_params)
+        qp.is_valid(raise_exception=True)
+        self.validated_query_params = qp.validated_data
+
+        return super().list(request, *args, **kwargs)
 
     def get_queryset(self) -> QuerySet[Notification]:
-        # 쿼리파라미터 검증
-        qp = NotificationListSerializer(data=self.request.query_params)
-        qp.is_valid(raise_exception=True)
-        is_read = qp.validated_data.get("is_read", None)
-        notification_type = qp.validated_data.get("type")
         user = cast(User, self.request.user)
 
         # 서비스 호출 (검증된 값만 전달)
-        return NotificationService.get_notifications_list(
-            user_id=user.id, is_read=is_read, notification_type=notification_type
-        )
+        return NotificationService.get_notifications_list(user_id=user.id, **self.validated_query_params)
 
 
 @extend_schema(

--- a/apps/notifications/views.py
+++ b/apps/notifications/views.py
@@ -1,6 +1,5 @@
-from typing import Any
+from typing import Any, cast
 
-from django.db import transaction
 from django.db.models import QuerySet
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
@@ -13,11 +12,14 @@ from rest_framework.views import APIView
 from apps.notifications.models import Notification
 from apps.notifications.pagination import NotificationLimitOffsetPagination
 from apps.notifications.serializers import (
+    NotificationListSerializer,
     NotificationSerializer,
     NotificationUpdateSerializer,
     UnreadCountOut,
     UnreadCountSerializer,
 )
+from apps.notifications.services.read_service import NotificationService
+from apps.users.models.user import User
 
 STATUS_ALL = "all"
 STATUS_UNREAD = "unread"
@@ -40,12 +42,15 @@ class NotificationListView(ListAPIView[Notification]):
     permission_classes = [IsAuthenticated]
 
     def get_queryset(self) -> QuerySet[Notification]:
-        assert self.request.user.is_authenticated  # 인증 유저가 아니면 AssertionError를 발생시켜 요청 처리를 중단
-        user_id = self.request.user.id
+        # 쿼리파라미터 검증
+        qp = NotificationListSerializer(data=self.request.query_params)
+        qp.is_valid(raise_exception=True)
+        is_read = qp.validated_data.get("is_read", None)
 
-        status_param = self.request.query_params.get("status", "all")
+        user = cast(User, self.request.user)
 
-        return Notification.objects.list_queryset(user_id=user_id, status=status_param)
+        # 서비스 호출 (검증된 값만 전달)
+        return NotificationService.get_notifications_list(user_id=user.id, is_read=is_read)
 
 
 @extend_schema(
@@ -62,11 +67,9 @@ class NotificationUpdateView(APIView):
 
     permission_classes = [IsAuthenticated]
 
-    @transaction.atomic
     def post(self, request: Request, notification_id: int, *args: Any, **kwargs: Any) -> Response:
-        update = Notification.objects.read_only_one_queryset(notification_id=notification_id, user_id=request.user.pk)
-        if update == 0:
-            return Response({"detail": "Notification not found or access denied."}, status=status.HTTP_404_NOT_FOUND)
+        user = cast(User, request.user)
+        NotificationService.read_notification(notification_id=notification_id, user_id=user.id)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
@@ -81,7 +84,11 @@ class NotificationReadAllView(APIView):
     모든 알림 일괄 읽음 처리
     """
 
+    permission_classes = [IsAuthenticated]
+
     def post(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        user = cast(User, request.user)
+        NotificationService.read_all_user_notifications(user_id=user.id)
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 

--- a/apps/notifications/views.py
+++ b/apps/notifications/views.py
@@ -21,10 +21,6 @@ from apps.notifications.serializers import (
 from apps.notifications.services.read_service import NotificationService
 from apps.users.models.user import User
 
-STATUS_ALL = "all"
-STATUS_UNREAD = "unread"
-STATUS_READ = "read"
-
 
 @extend_schema(
     tags=["Notifications"],
@@ -46,11 +42,13 @@ class NotificationListView(ListAPIView[Notification]):
         qp = NotificationListSerializer(data=self.request.query_params)
         qp.is_valid(raise_exception=True)
         is_read = qp.validated_data.get("is_read", None)
-
+        notification_type = qp.validated_data.get("type")
         user = cast(User, self.request.user)
 
         # 서비스 호출 (검증된 값만 전달)
-        return NotificationService.get_notifications_list(user_id=user.id, is_read=is_read)
+        return NotificationService.get_notifications_list(
+            user_id=user.id, is_read=is_read, notification_type=notification_type
+        )
 
 
 @extend_schema(


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #75
- 작업 요약: 특정 알림 읽음 api를 mock -> db기반으로 전환

## 📄 상세 내용
- [x] ORM 접근 managers로 전환
- [x] mock 기반에서 db기반으로 전환

## 📸 스크린샷 (선택)
<img width="1834" height="987" alt="스크린샷 2025-09-10 오전 11 46 22" src="https://github.com/user-attachments/assets/8d4a2970-44b7-4ecc-b2ed-e6df49e4b4bd" />

## 📝 기타 참고 사항
해당 알림만 읽음 처리 후 클릭하여 백링크로 이동에 대한 로직은 추후 서비스 레이어에서 django-signals와 selery task를 통해 구현 예정
## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
