### PR TITLE
♻️ refactor: user part urls 분리

### DIFF
--- a/apps/users/urls/__init__.py
+++ b/apps/users/urls/__init__.py
@@ -1,0 +1,4 @@
+from apps.users.urls.auth_urls import urlpatterns as auth_urls
+from apps.users.urls.users_urls import urlpatterns as users_urls
+
+urlpatterns = auth_urls + users_urls

--- a/apps/users/urls/admin_urls.py
+++ b/apps/users/urls/admin_urls.py
@@ -1,9 +1,9 @@
 from django.urls import URLPattern, URLResolver, path
 
-from apps.users.views.admin_views import UserPermissionAPIView
+# from apps.users.views.admin_views import UserPermissionAPIView
 
 app_name = "admin_user"
 
 urlpatterns: list[URLPattern | URLResolver] = [
-    path("/<uuid:user_uuid>", UserPermissionAPIView.as_view(), name="user_permissions"),
+    # path("/<uuid:user_uuid>", UserPermissionAPIView.as_view(), name="user_permissions"),
 ]

--- a/apps/users/urls/admin_urls.py
+++ b/apps/users/urls/admin_urls.py
@@ -1,0 +1,9 @@
+from django.urls import URLPattern, URLResolver, path
+
+from apps.users.views.admin_views import UserPermissionAPIView
+
+app_name = "admin_user"
+
+urlpatterns: list[URLPattern | URLResolver] = [
+    path("/<uuid:user_uuid>", UserPermissionAPIView.as_view(), name="user_permissions"),
+]

--- a/apps/users/urls/auth_urls.py
+++ b/apps/users/urls/auth_urls.py
@@ -1,4 +1,4 @@
-from django.urls import path
+from django.urls import URLPattern, URLResolver, path
 
 from apps.users.views.email_view import (
     SignUpEmailVerificationSendAPIView,
@@ -7,10 +7,10 @@ from apps.users.views.email_view import (
 from apps.users.views.phone_view import SendVerificationCodeAPIView, VerifyCodeAPIView
 from apps.users.views.withdrawals import WithdrawalAPIView
 
-urlpatterns = [
-    path("email/send-code", SignUpEmailVerificationSendAPIView.as_view(), name="email_send_code"),
-    path("email/verify", SignUpEmailVerifiCationVerifyAPIView.as_view(), name="email_verify_code"),
-    path("phone/send-code", SendVerificationCodeAPIView.as_view(), name="phone_send_code"),
-    path("phone/verify-code", VerifyCodeAPIView.as_view(), name="phone_verify_code"),
-    path("withdraw", WithdrawalAPIView.as_view(), name="account_withdrawals"),
+urlpatterns: list[URLPattern | URLResolver] = [
+    path("auth/email/send-code", SignUpEmailVerificationSendAPIView.as_view(), name="email_send_code"),
+    path("auth/email/verify", SignUpEmailVerifiCationVerifyAPIView.as_view(), name="email_verify_code"),
+    path("auth/phone/send-code", SendVerificationCodeAPIView.as_view(), name="phone_send_code"),
+    path("auth/phone/verify-code", VerifyCodeAPIView.as_view(), name="phone_verify_code"),
+    path("auth/withdraw", WithdrawalAPIView.as_view(), name="account_withdrawals"),
 ]

--- a/apps/users/urls/users_urls.py
+++ b/apps/users/urls/users_urls.py
@@ -1,0 +1,3 @@
+from django.urls import URLPattern, URLResolver, path
+
+urlpatterns: list[URLPattern | URLResolver] = []

--- a/config/urls.py
+++ b/config/urls.py
@@ -8,7 +8,8 @@ from drf_spectacular.views import (
 )
 
 urlpatterns: list[URLPattern | URLResolver] = [
-    path("api/v1/auth/", include("apps.users.urls.auth_urls")),
+    path("api/v1/", include("apps.users.urls")),
+    path("api/v1/admin/users", include("apps.users.urls.admin_urls")),
     path("api/v1/notifications", include("apps.notifications.urls")),
     path("api/v1/recruitments", include("apps.recruitments.urls")),
 ]


### PR DESCRIPTION
users,auth url을 apps.users.urls.__init__에서 관리하고, users의 admin url은 config.urls에서 include하도록 변경

## ✅ PR 요약
- 관련 이슈 번호: #86 
- 작업 요약: user part urls 분리

## 📄 상세 내용
- [x] config url에 admin url 추가
- [x] users urls에서 auth_urls와 users_urls을 관리할 수 있도록 수정

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
