### PR TITLE
♻️ refactor: config에 admin urls 추가 & urls를 include로 관리하도록 변경

### DIFF
--- a/apps/applications/urls/admin_urls.py
+++ b/apps/applications/urls/admin_urls.py
@@ -1,5 +1,3 @@
 from django.urls import URLPattern, URLResolver, path
 
-urlpatterns: list[URLPattern | URLResolver] = [
-
-]
+urlpatterns: list[URLPattern | URLResolver] = []

--- a/apps/applications/urls/admin_urls.py
+++ b/apps/applications/urls/admin_urls.py
@@ -1,0 +1,5 @@
+from django.urls import URLPattern, URLResolver, path
+
+urlpatterns: list[URLPattern | URLResolver] = [
+
+]

--- a/apps/recruitments/urls/__init__.py
+++ b/apps/recruitments/urls/__init__.py
@@ -1,7 +1,0 @@
-from apps.recruitments.urls.recruitments_urls import urlpatterns as recruitments_urls
-from apps.recruitments.urls.tags_urls import urlpatterns as tags_urls
-
-urlpatterns = [
-    *recruitments_urls,
-    *tags_urls,
-]

--- a/apps/recruitments/urls/__init__.py
+++ b/apps/recruitments/urls/__init__.py
@@ -1,0 +1,6 @@
+from django.urls import URLPattern, URLResolver, include, path
+
+urlpatterns: list[URLPattern | URLResolver] = [
+    path("", include("apps.recruitments.urls.recruitments_urls")),
+    path("", include("apps.recruitments.urls.tags_urls")),
+]

--- a/apps/recruitments/urls/admin_urls.py
+++ b/apps/recruitments/urls/admin_urls.py
@@ -1,5 +1,3 @@
 from django.urls import URLPattern, URLResolver, path
 
-urlpatterns: list[URLPattern | URLResolver] = [
-
-]
+urlpatterns: list[URLPattern | URLResolver] = []

--- a/apps/recruitments/urls/admin_urls.py
+++ b/apps/recruitments/urls/admin_urls.py
@@ -1,0 +1,5 @@
+from django.urls import URLPattern, URLResolver, path
+
+urlpatterns: list[URLPattern | URLResolver] = [
+
+]

--- a/apps/recruitments/urls/main.py
+++ b/apps/recruitments/urls/main.py
@@ -1,0 +1,6 @@
+from django.urls import URLPattern, URLResolver, include, path
+
+urlpatterns: list[URLPattern | URLResolver] = [
+    path("", include("apps.recruitments.urls.recruitments_urls")),
+    path("", include("apps.recruitments.urls.tags_urls")),
+]

--- a/apps/recruitments/urls/main.py
+++ b/apps/recruitments/urls/main.py
@@ -1,6 +1,0 @@
-from django.urls import URLPattern, URLResolver, include, path
-
-urlpatterns: list[URLPattern | URLResolver] = [
-    path("", include("apps.recruitments.urls.recruitments_urls")),
-    path("", include("apps.recruitments.urls.tags_urls")),
-]

--- a/apps/recruitments/urls/recruitments_urls.py
+++ b/apps/recruitments/urls/recruitments_urls.py
@@ -1,9 +1,9 @@
-from django.urls import path
+from django.urls import URLPattern, URLResolver, path
 
 from apps.recruitments.views.recruitments_views import RecruitmentDetailView
 from apps.recruitments.views.views_list import RecruitmentView
 
-urlpatterns = [
+urlpatterns: list[URLPattern | URLResolver] = [
     path("", RecruitmentView.as_view(), name="recruitment-list"),
     path("/<uuid:recruitment_uuid>", RecruitmentDetailView.as_view(), name="recruitment-detail"),
 ]

--- a/apps/recruitments/urls/tags_urls.py
+++ b/apps/recruitments/urls/tags_urls.py
@@ -1,8 +1,8 @@
-from django.urls import path
+from django.urls import URLPattern, URLResolver, path
 
 from ..views.tags_views import TagAPIView
 
-urlpatterns = [
+urlpatterns: list[URLPattern | URLResolver] = [
     # GET, POST 모두 동일한 URL을 사용한다.
     # .as_view() 메서드는 클래스 기반 뷰를 URL에 연결할 때 사용하는 표준 방식이다.
     path("/tags", TagAPIView.as_view(), name="tag-list"),

--- a/apps/study_group_schedules/urls.py
+++ b/apps/study_group_schedules/urls.py
@@ -4,9 +4,6 @@ from django.urls import URLPattern, path
 
 from apps.study_group_schedules import views
 
-app_name = "study_group_schedules"
-
 urlpatterns: List[URLPattern] = [
-    # POST /api/v1/schedules
     path("", views.StudyGroupScheduleCreateView.as_view(), name="create_schedule"),
 ]

--- a/apps/study_group_schedules/urls/__init__.py
+++ b/apps/study_group_schedules/urls/__init__.py
@@ -1,3 +1,0 @@
-from .urls import urlpatterns
-
-__all__ = ["urlpatterns"]

--- a/apps/users/urls/__init__.py
+++ b/apps/users/urls/__init__.py
@@ -1,1 +1,6 @@
+from django.urls import URLPattern, URLResolver, include, path
 
+urlpatterns: list[URLPattern | URLResolver] = [
+    path("auth", include("apps.users.urls.auth_urls")),
+    path("users", include("apps.users.urls.users_urls")),
+]

--- a/apps/users/urls/__init__.py
+++ b/apps/users/urls/__init__.py
@@ -1,4 +1,1 @@
-from apps.users.urls.auth_urls import urlpatterns as auth_urls
-from apps.users.urls.users_urls import urlpatterns as users_urls
 
-urlpatterns = auth_urls + users_urls

--- a/apps/users/urls/auth_urls.py
+++ b/apps/users/urls/auth_urls.py
@@ -8,9 +8,9 @@ from apps.users.views.phone_view import SendVerificationCodeAPIView, VerifyCodeA
 from apps.users.views.withdrawals import WithdrawalAPIView
 
 urlpatterns: list[URLPattern | URLResolver] = [
-    path("auth/email/send-code", SignUpEmailVerificationSendAPIView.as_view(), name="email_send_code"),
-    path("auth/email/verify", SignUpEmailVerifiCationVerifyAPIView.as_view(), name="email_verify_code"),
-    path("auth/phone/send-code", SendVerificationCodeAPIView.as_view(), name="phone_send_code"),
-    path("auth/phone/verify-code", VerifyCodeAPIView.as_view(), name="phone_verify_code"),
-    path("auth/withdraw", WithdrawalAPIView.as_view(), name="account_withdrawals"),
+    path("/email/send-code", SignUpEmailVerificationSendAPIView.as_view(), name="email_send_code"),
+    path("/email/verify", SignUpEmailVerifiCationVerifyAPIView.as_view(), name="email_verify_code"),
+    path("/phone/send-code", SendVerificationCodeAPIView.as_view(), name="phone_send_code"),
+    path("/phone/verify-code", VerifyCodeAPIView.as_view(), name="phone_verify_code"),
+    path("/withdraw", WithdrawalAPIView.as_view(), name="account_withdrawals"),
 ]

--- a/apps/users/urls/main.py
+++ b/apps/users/urls/main.py
@@ -1,6 +1,0 @@
-from django.urls import URLPattern, URLResolver, include, path
-
-urlpatterns: list[URLPattern | URLResolver] = [
-    path("auth", include("apps.users.urls.auth_urls")),
-    path("users", include("apps.users.urls.users_urls")),
-]

--- a/apps/users/urls/main.py
+++ b/apps/users/urls/main.py
@@ -1,0 +1,6 @@
+from django.urls import URLPattern, URLResolver, include, path
+
+urlpatterns: list[URLPattern | URLResolver] = [
+    path("auth", include("apps.users.urls.auth_urls")),
+    path("users", include("apps.users.urls.users_urls")),
+]

--- a/config/admin_urls.py
+++ b/config/admin_urls.py
@@ -1,0 +1,5 @@
+from django.urls import URLPattern, URLResolver, include, path
+
+urlpatterns: list[URLPattern | URLResolver] = [
+    path("users", include("apps.users.urls.admin_urls")),
+]

--- a/config/admin_urls.py
+++ b/config/admin_urls.py
@@ -1,5 +1,0 @@
-from django.urls import URLPattern, URLResolver, include, path
-
-urlpatterns: list[URLPattern | URLResolver] = [
-    path("users", include("apps.users.urls.admin_urls")),
-]

--- a/config/urls.py
+++ b/config/urls.py
@@ -7,13 +7,27 @@ from drf_spectacular.views import (
     SpectacularSwaggerView,
 )
 
-urlpatterns: list[URLPattern | URLResolver] = [
-    path("api/v1/admin/", include("config.admin_urls")),
-    path("api/v1/", include("apps.users.urls.main")),
+apps_urlpatterns: list[URLPattern | URLResolver] = [
+    path("api/v1/", include("apps.users.urls")),
     path("api/v1/notifications", include("apps.notifications.urls")),
-    path("api/v1/recruitments", include("apps.recruitments.urls.main")),
+    path("api/v1/recruitments", include("apps.recruitments.urls")),
     path("api/v1/schedules", include("apps.study_group_schedules.urls")),
 ]
+
+admin_urlpatterns: list[URLPattern | URLResolver] = [
+    path(
+        "api/v1/admin/",
+        include(
+            [
+                path("", include("apps.users.urls.admin_urls")),
+                path("", include("apps.recruitments.urls.admin_urls")),
+                path("", include("apps.applications.urls.admin_urls")),
+            ]
+        ),
+    ),
+]
+
+urlpatterns = apps_urlpatterns + admin_urlpatterns
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/config/urls.py
+++ b/config/urls.py
@@ -8,10 +8,10 @@ from drf_spectacular.views import (
 )
 
 urlpatterns: list[URLPattern | URLResolver] = [
-    path("api/v1/", include("apps.users.urls")),
-    path("api/v1/admin/users", include("apps.users.urls.admin_urls")),
+    path("api/v1/admin/", include("config.admin_urls")),
+    path("api/v1/", include("apps.users.urls.main")),
     path("api/v1/notifications", include("apps.notifications.urls")),
-    path("api/v1/recruitments", include("apps.recruitments.urls")),
+    path("api/v1/recruitments", include("apps.recruitments.urls.main")),
     path("api/v1/schedules", include("apps.study_group_schedules.urls")),
 ]
 


### PR DESCRIPTION
그룹 스케쥴 urls 파일 하나로 관리 하도록 변경, 각 앱들 urls/__init__이 아닌 include로 관리하도록 변경

## ✅ PR 요약
- 관련 이슈 번호: #92 
- 작업 요약: 그룹 스케쥴 urls 파일 하나로 관리 하도록 변경, 각 앱들 urls/__init__이 아닌 include로 관리하도록 변경

## 📄 상세 내용
- [x] 그룹 스케쥴 urls 파일 하나로 관리 하도록 변경
- [x] 각 앱들 urls/__init__이 아닌 include로 관리하도록 변경

### prefix 중복 줄이기, url 계층 구조 형성, admin endpoint 관리 등 여러 방면으로 이 방식이 나은 것 같다는 생각이 들어서 변경 요청합니다.

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
