### PR TITLE
미읽음 알림 개수 api

### DIFF
--- a/apps/notifications/managers.py
+++ b/apps/notifications/managers.py
@@ -10,3 +10,6 @@ if TYPE_CHECKING:
 class NotificationManager(models.Manager["Notification"]):
     def get_list_by_user_id_and_is_read(self, user_id: int, is_read: bool) -> QuerySet["Notification"]:
         return self.get_queryset().filter(user_id=user_id, is_read=is_read)
+
+    def unread_count(self, user_id: int) -> int:
+        return self.get_queryset().filter(user_id=user_id, is_read=False).count()

--- a/apps/notifications/services/read_service.py
+++ b/apps/notifications/services/read_service.py
@@ -37,3 +37,7 @@ class NotificationService:
     def read_all_user_notifications(cls, user_id: int) -> int:
         notifications = Notification.objects.get_list_by_user_id_and_is_read(user_id=user_id, is_read=False)
         return notifications.update(is_read=True)
+
+    @classmethod
+    def get_unread_count(cls, user_id: int) -> int:
+        return Notification.objects.unread_count(user_id=user_id)

--- a/apps/notifications/views.py
+++ b/apps/notifications/views.py
@@ -40,7 +40,9 @@ class NotificationListView(ListAPIView[Notification]):
 
     def list(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         # 쿼리파라미터 검증
-        qp = NotificationListQueryParamsSerializer(data=self.request.query_params)
+        qp = NotificationListQueryParamsSerializer(
+            data=self.request.query_params
+        )  # 본문 데이터가 request.query_params로 저장
         qp.is_valid(raise_exception=True)
         self.validated_query_params = qp.validated_data
 
@@ -103,8 +105,11 @@ class UnreadCountView(APIView):
     읽지 않은 알림 수 조회
     """
 
-    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        mock_count: UnreadCountOut = {"unread_count": 5}
+    permission_classes = [IsAuthenticated]
 
-        serializer = UnreadCountSerializer(instance=mock_count)
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        user = cast(User, request.user)
+        count = NotificationService.get_unread_count(user_id=user.id)
+        payload: UnreadCountOut = {"unread_count": count}
+        serializer = UnreadCountSerializer(instance=payload)
         return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION

## ✅ PR 요약
- 관련 이슈 번호: #99
- 작업 요약: 미읽음 알림에 대한 개수 카운트

## 📄 상세 내용
- [x] is_read=False 필터하여 미읽음 개수 카운트

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
