### PR TITLE
Feature/recruitments application

### DIFF
--- a/apps/applications/application_views.py
+++ b/apps/applications/application_views.py
@@ -1,0 +1,75 @@
+from typing import cast
+from uuid import UUID
+
+from django.db import IntegrityError
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.applications.serializers.application_serializers import (
+    ApplicationCreateSerializer,
+)
+from apps.recruitments.models import Recruitment
+from apps.users.models import User
+
+from .models import Application
+
+
+class ApplicationAPIView(APIView):
+    """
+    APIView를 상속받아 HTTP 메서드(post)에 따른 로직을 직접 구현.
+    전체 작업 흐름을 조율하는 Orchestrator 역할을 한다.
+    """
+
+    # IsAuthenticated: 요청을 보낸 사용자가 로그인 상태인지(인증되었는지) 확인.
+    # 인증되지 않은 사용자의 요청은 401 Unauthorized 에러를 반환하며 post 메서드가 실행되지 않는다.
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request: Request, recruitment_uuid: UUID) -> Response:
+        # 지원서 생성 요청(POST)을 처리.
+
+        # --- 1. 공고 객체 조회 --- #
+        # URL로 받은 recruitment_uuid를 사용해 지원 대상 공고 객체를 조회.
+        # 만약 해당 uuid의 공고가 없으면 DoesNotExist 예외가 발생하며, 이는 API의 핵심 로직을
+        # 수행하기 위한 기본 조건이므로, 즉시 404 Not Found 응답을 반환하고 처리를 중단한다.
+        try:
+            recruitment = Recruitment.objects.get(uuid=recruitment_uuid)
+        except Recruitment.DoesNotExist:
+            return Response(
+                {"error_code": "RECRUITMENT_NOT_FOUND", "message": "해당 스터디 공고를 찾을 수 없습니다."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        # --- 2. 데이터 유효성 검사 --- #
+        # 클라이언트가 보낸 데이터를 ApplicationCreateSerializer에 넘겨 유효성을 검사.
+        # is_valid()는 모델 필드의 기본 제약조건과 Serializer에 직접 정의한 validate 메서드를 모두 실행한다.
+        serializer = ApplicationCreateSerializer(data=request.data)
+        if not serializer.is_valid():
+            # 유효성 검사에 실패하면, 어떤 필드가 왜 실패했는지에 대한 정보가 serializer.errors에 담긴다.
+            # 이 정보를 400 Bad Request 응답에 담아 클라이언트에게 전달한다.
+            return Response(
+                {"error_code": "INVALID_INPUT", "message": serializer.errors}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        # --- 3. 핵심 로직(지원서 생성) 호출 및 결과 처리 --- #
+        # 모든 검증을 통과하면, View가 직접 DB 로직을 처리하지 않고 Manager에게 로직을 위임한다.
+        # user, recruitment 객체와 유효성 검사를 마친 데이터(serializer.validated_data)를 전달한다.
+        try:
+            # IsAuthenticated 권한 클래스에 의해 이 시점의 request.user는 항상 User 객체임이 보장된다..
+            user = cast(User, request.user)
+            application = Application.objects.create_application(
+                user=user, recruitment=recruitment, **serializer.validated_data
+            )
+        # Manager의 create_application 메서드에서 중복 지원 시 IntegrityError를 발생시키기로 약속했으므로,
+        # 이 예외를 받아서, API 명세에 맞는 403 Forbidden 응답을 생성하여 반환한다.
+        except IntegrityError as e:
+            return Response(
+                {"error_code": "DUPLICATE_APPLICATION", "message": str(e)}, status=status.HTTP_403_FORBIDDEN
+            )
+
+        # 모든 과정이 성공적으로 끝나면, 생성된 지원서의 ID를 포함하여 201 Created 응답을 반환한다.
+        return Response(
+            {"application_id": application.id, "message": "스터디 공고 참여 신청 성공"}, status=status.HTTP_201_CREATED
+        )

--- a/apps/applications/application_views.py
+++ b/apps/applications/application_views.py
@@ -11,10 +11,9 @@ from rest_framework.views import APIView
 from apps.applications.serializers.application_serializers import (
     ApplicationCreateSerializer,
 )
+from apps.applications.services import ApplicationService
 from apps.recruitments.models import Recruitment
 from apps.users.models import User
-
-from .models import Application
 
 
 class ApplicationAPIView(APIView):
@@ -28,7 +27,7 @@ class ApplicationAPIView(APIView):
     permission_classes = [IsAuthenticated]
 
     def post(self, request: Request, recruitment_uuid: UUID) -> Response:
-        # 지원서 생성 요청(POST)을 처리.
+        """지원서 생성 요청(POST)을 처리한다."""
 
         # --- 1. 공고 객체 조회 --- #
         # URL로 받은 recruitment_uuid를 사용해 지원 대상 공고 객체를 조회.
@@ -54,20 +53,18 @@ class ApplicationAPIView(APIView):
             )
 
         # --- 3. 핵심 로직(지원서 생성) 호출 및 결과 처리 --- #
-        # 모든 검증을 통과하면, View가 직접 DB 로직을 처리하지 않고 Manager에게 로직을 위임한다.
+        # View는 Service 레이어에 로직 처리를 위임한다.
         # user, recruitment 객체와 유효성 검사를 마친 데이터(serializer.validated_data)를 전달한다.
         try:
-            # IsAuthenticated 권한 클래스에 의해 이 시점의 request.user는 항상 User 객체임이 보장된다..
+            # IsAuthenticated 권한 클래스에 의해 이 시점의 request.user는 항상 User 객체임이 보장된다.
+            # mypy에게 이 사실을 알려주기 위해 cast를 사용하여 타입을 명시적으로 지정한다.
             user = cast(User, request.user)
-            application = Application.objects.create_application(
-                user=user, recruitment=recruitment, **serializer.validated_data
-            )
-        # Manager의 create_application 메서드에서 중복 지원 시 IntegrityError를 발생시키기로 약속했으므로,
-        # 이 예외를 받아서, API 명세에 맞는 403 Forbidden 응답을 생성하여 반환한다.
-        except IntegrityError as e:
-            return Response(
-                {"error_code": "DUPLICATE_APPLICATION", "message": str(e)}, status=status.HTTP_403_FORBIDDEN
-            )
+            service = ApplicationService()
+            application = service.create_application(user=user, recruitment=recruitment, **serializer.validated_data)
+        # Service(내부적으로는 Manager)에서 중복 지원 시 IntegrityError를 발생시키기로 약속했으므로,
+        # 이 예외를 받아서, 409 Conflict 응답을 생성하여 반환한다.
+        except IntegrityError as e:  # <-- 데이터베이스의 UniqueConstraint 위반 시 발생하는 IntegrityError를 잡습니다.
+            return Response({"error_code": "DUPLICATE_APPLICATION", "message": str(e)}, status=status.HTTP_409_CONFLICT)
 
         # 모든 과정이 성공적으로 끝나면, 생성된 지원서의 ID를 포함하여 201 Created 응답을 반환한다.
         return Response(

--- a/apps/applications/managers/application_managers.py
+++ b/apps/applications/managers/application_managers.py
@@ -12,10 +12,19 @@ if TYPE_CHECKING:
 
 
 class ApplicationManager(models.Manager["Application"]):
-    """
-    Application 모델에 대한 커스텀 비즈니스 로직을 정의하는 매니저.
-    View와 같은 다른 계층에서 ORM 관련 로직을 분리하여 코드의 응집도와 재사용성을 높인다.
-    """
+
+    def has_applied(self, user: User, recruitment: Recruitment) -> bool:
+        """
+        사용자가 특정 공고에 이미 지원했는지 확인한다.
+
+        Args:
+            user (User): 확인할 사용자 객체
+            recruitment (Recruitment): 확인할 공고 객체
+
+        Returns:
+            bool: 지원 이력이 있으면 True, 없으면 False
+        """
+        return self.filter(user=user, recruitment=recruitment).exists()
 
     def create_application(
         self,
@@ -24,25 +33,16 @@ class ApplicationManager(models.Manager["Application"]):
         **validated_data: Any,
     ) -> Application:
         """
-        '중복 지원 불가' 규칙을 적용하여 Application 객체를 생성한다.
+        Application 객체를 생성한다. (사전 조건: 중복 지원 검사는 이미 완료되어야 함)
 
         Args:
             user (User): 지원하는 사용자 객체
             recruitment (Recruitment): 지원 대상이 되는 공고 객체
             **validated_data: Serializer를 통해 유효성 검사를 마친 데이터
 
-        Raises:
-            IntegrityError: 동일한 사용자가 동일한 공고에 이미 지원했을 경우 발생
-
         Returns:
             Application: 성공적으로 생성된 Application 객체
         """
-        # exists()를 사용하여 DB에 공고 지원 이력 데이터 존재 여부만 확인한다.
-        # 실제 데이터를 가져오지 않으므로 get()이나 filter()보다 효율적이다.
-        if self.filter(user=user, recruitment=recruitment).exists():
-            # View에서 받아서 처리할 수 있도록, '데이터 무결성 위반'을 의미하는 IntegrityError를 발생시킨다.
-            raise IntegrityError("이미 해당 공고에 지원한 이력이 있습니다.")
-
-        # 모든 검증을 통과하면, 기본 create 메서드를 호출하여 객체를 생성하고 반환한다.
+        # 생성 로직만 남긴다.
         application = self.create(user=user, recruitment=recruitment, **validated_data)
         return application

--- a/apps/applications/managers/application_managers.py
+++ b/apps/applications/managers/application_managers.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from django.db import IntegrityError, models
+
+from apps.recruitments.models import Recruitment
+from apps.users.models import User
+
+if TYPE_CHECKING:
+    from ..models import Application
+
+
+class ApplicationManager(models.Manager["Application"]):
+    """
+    Application 모델에 대한 커스텀 비즈니스 로직을 정의하는 매니저.
+    View와 같은 다른 계층에서 ORM 관련 로직을 분리하여 코드의 응집도와 재사용성을 높인다.
+    """
+
+    def create_application(
+        self,
+        user: User,
+        recruitment: Recruitment,
+        **validated_data: Any,
+    ) -> Application:
+        """
+        '중복 지원 불가' 규칙을 적용하여 Application 객체를 생성한다.
+
+        Args:
+            user (User): 지원하는 사용자 객체
+            recruitment (Recruitment): 지원 대상이 되는 공고 객체
+            **validated_data: Serializer를 통해 유효성 검사를 마친 데이터
+
+        Raises:
+            IntegrityError: 동일한 사용자가 동일한 공고에 이미 지원했을 경우 발생
+
+        Returns:
+            Application: 성공적으로 생성된 Application 객체
+        """
+        # exists()를 사용하여 DB에 공고 지원 이력 데이터 존재 여부만 확인한다.
+        # 실제 데이터를 가져오지 않으므로 get()이나 filter()보다 효율적이다.
+        if self.filter(user=user, recruitment=recruitment).exists():
+            # View에서 받아서 처리할 수 있도록, '데이터 무결성 위반'을 의미하는 IntegrityError를 발생시킨다.
+            raise IntegrityError("이미 해당 공고에 지원한 이력이 있습니다.")
+
+        # 모든 검증을 통과하면, 기본 create 메서드를 호출하여 객체를 생성하고 반환한다.
+        application = self.create(user=user, recruitment=recruitment, **validated_data)
+        return application

--- a/apps/applications/models/applications.py
+++ b/apps/applications/models/applications.py
@@ -1,5 +1,6 @@
 from django.db import models
 
+from apps.applications.managers.application_managers import ApplicationManager
 from apps.core.models import BaseModel
 from apps.recruitments.models.recruitments import Recruitment
 from apps.users.models.user import User
@@ -42,6 +43,10 @@ class Application(BaseModel):
         default=ApplicationStatus.PENDING,
         help_text="공고 지원 상태",
     )
+
+    # 커스텀 매니저인 ApplicationManager를 기본 매니저('objects')로 지정합니다.
+    # 이를 통해 Application.objects.create_application()과 같은 커스텀 메서드를 사용할 수 있게 됩니다.
+    objects = ApplicationManager()
 
     class Meta:
         db_table = "applications"

--- a/apps/applications/serializers/application_serializers.py
+++ b/apps/applications/serializers/application_serializers.py
@@ -1,0 +1,41 @@
+from typing import Any
+
+from rest_framework import serializers
+
+from apps.applications.models import Application
+
+
+class ApplicationCreateSerializer(serializers.ModelSerializer[Application]):
+    """
+    - ModelSerializer를 상속받아 Application 모델과 연동됩니다.
+    - 클라이언트로부터 받은 데이터의 유효성을 검증하고, Python 객체로 변환하는 역할을 한다.
+    """
+
+    class Meta:
+        # 이 Serializer가 Application 모델을 기반으로 동작하도록 설정한다.
+        # ModelSerializer는 이 설정을 보고 필드를 자동으로 생성하고 기본 유효성 검사를 수행한다.
+        model = Application
+        # 클라이언트로부터 직접 입력받을 필드들을 명시한다.
+        fields = [
+            "self_introduction",
+            "motivation",
+            "objective",
+            "available_time",
+            "has_study_experience",
+            "study_experience",
+        ]
+
+    def validate(self, data: dict[str, Any]) -> dict[str, Any]:
+        """
+        DRF의 기본 유효성 검사가 끝난 후 호출되는 커스텀 유효성 검사 메서드.
+        필드 간의 연관 관계 등 복잡한 비즈니스 규칙을 이곳에 구현한다.
+        """
+        # '스터디 경험 있음'을 선택했지만, 경험 내용을 적지 않은 경우 에러를 발생시킴.
+        if data.get("has_study_experience") and not data.get("study_experience"):
+            # ValidationError를 발생시키면, is_valid()가 False를 반환하고
+            # serializer.errors에 해당 오류 메시지를 발생시킴.
+            raise serializers.ValidationError(
+                {"study_experience": "스터디 경험이 있다고 응답한 경우, 구체적인 경험을 필수로 입력해야 합니다."}
+            )
+        # 유효성 검사를 통과하면, 검증된 데이터를 그대로 반환.
+        return data

--- a/apps/applications/services/__init__.py
+++ b/apps/applications/services/__init__.py
@@ -1,0 +1,3 @@
+from .application_services import ApplicationService
+
+__all__ = ["ApplicationService"]

--- a/apps/applications/services/application_services.py
+++ b/apps/applications/services/application_services.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from apps.applications.models import Application
+from apps.recruitments.models import Recruitment
+from apps.users.models import User
+
+if TYPE_CHECKING:
+    from ..models import Application
+
+
+class ApplicationService:
+    """
+    지원서 생성 및 관리를 담당하는 서비스 클래스
+    """
+
+    def create_application(
+        self,
+        user: User,
+        recruitment: Recruitment,
+        **validated_data: Any,
+    ) -> Application:
+
+        # Manager를 통해 실제 DB 로직을 수행하고, 서비스는 그 흐름을 제어한다.
+        application = Application.objects.create_application(user=user, recruitment=recruitment, **validated_data)
+        return application

--- a/apps/applications/services/application_services.py
+++ b/apps/applications/services/application_services.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
+
+from django.db import IntegrityError
 
 from apps.applications.models import Application
 from apps.recruitments.models import Recruitment
 from apps.users.models import User
-
-if TYPE_CHECKING:
-    from ..models import Application
 
 
 class ApplicationService:
@@ -22,6 +21,10 @@ class ApplicationService:
         **validated_data: Any,
     ) -> Application:
 
-        # Manager를 통해 실제 DB 로직을 수행하고, 서비스는 그 흐름을 제어한다.
+        # 서비스 계층에서 중복 지원 여부를 먼저 확인한다.
+        if Application.objects.has_applied(user=user, recruitment=recruitment):
+            raise IntegrityError("이미 해당 공고에 지원한 이력이 있습니다.")
+
+        # 중복이 아닐 경우, Manager의 생성 메서드를 호출한다.
         application = Application.objects.create_application(user=user, recruitment=recruitment, **validated_data)
         return application

--- a/apps/applications/tests/test_applications.py
+++ b/apps/applications/tests/test_applications.py
@@ -85,7 +85,7 @@ class ApplicationAPITest(APITestCase):
         self.client.force_authenticate(user=self.applicant)
         response = self.client.post(self.url, self.valid_payload, format="json")
 
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
         self.assertEqual(response.data["error_code"], "DUPLICATE_APPLICATION")
 
     def test_create_application_for_non_existent_recruitment_fails(self) -> None:

--- a/apps/applications/tests/test_applications.py
+++ b/apps/applications/tests/test_applications.py
@@ -1,0 +1,109 @@
+import uuid
+from datetime import datetime
+
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.recruitments.models import Recruitment
+from apps.studies.models import StudyGroup
+from apps.users.models import User
+
+from ..models import Application
+
+
+class ApplicationAPITest(APITestCase):
+    def setUp(self) -> None:
+        """테스트 케이스 실행 전에 초기 데이터 설정"""
+        # ERD를 참고하여 name, phone_number, gender, birthday 등 필수 필드를 추가한다.
+        # nickname과 phone_number는 unique 필드이므로 각 유저마다 다른 값을 사용한다.
+        self.applicant = User.objects.create_user(
+            email="applicant@test.com",
+            password="password",
+            name="지원자",
+            nickname="지원자닉네임",
+            phone_number="010-1111-1111",
+            gender="M",
+            birthday="2000-01-01",
+        )
+        self.author = User.objects.create_user(
+            email="author@test.com",
+            password="password",
+            name="작성자",
+            nickname="작성자닉네임",
+            phone_number="010-2222-2222",
+            gender="F",
+            birthday="1999-01-01",
+        )
+
+        # 시간대 정보가 포함된 'aware' datetime 객체를 생성한다.
+        aware_start_at = timezone.make_aware(datetime(2025, 1, 1))
+        aware_end_at = timezone.make_aware(datetime(2025, 3, 1))
+
+        self.study_group = StudyGroup.objects.create(
+            name="테스트 스터디", max_headcount=5, start_at=aware_start_at, end_at=aware_end_at
+        )
+        self.recruitment = Recruitment.objects.create(
+            author=self.author,
+            study_group=self.study_group,
+            title="테스트 공고",
+            content="내용",
+            expected_headcount=3,
+            estimated_fee=25000,
+        )
+
+        self.url = reverse("application-create", kwargs={"recruitment_uuid": self.recruitment.uuid})
+        self.valid_payload = {
+            "self_introduction": "안녕하세요",
+            "motivation": "성장하고 싶습니다",
+            "objective": "프로젝트 완수",
+            "available_time": "주중 저녁",
+            "has_study_experience": False,
+        }
+
+    def test_create_application_success(self) -> None:
+        """스터디 참여 신청 성공 테스트"""
+        self.client.force_authenticate(user=self.applicant)
+        response = self.client.post(self.url, self.valid_payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(Application.objects.filter(user=self.applicant, recruitment=self.recruitment).exists())
+        self.assertIn("application_id", response.data)
+
+    def test_create_application_unauthenticated_fails(self) -> None:
+        """미인증 사용자 참여 신청 실패 테스트"""
+        response = self.client.post(self.url, self.valid_payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_create_duplicate_application_fails(self) -> None:
+        """중복 지원 실패 테스트"""
+        # 먼저 한 번 지원
+        Application.objects.create(user=self.applicant, recruitment=self.recruitment, **self.valid_payload)
+
+        # 다시 지원 시도
+        self.client.force_authenticate(user=self.applicant)
+        response = self.client.post(self.url, self.valid_payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data["error_code"], "DUPLICATE_APPLICATION")
+
+    def test_create_application_for_non_existent_recruitment_fails(self) -> None:
+        """존재하지 않는 공고에 지원 실패 테스트"""
+        invalid_url = reverse("application-create", kwargs={"recruitment_uuid": uuid.uuid4()})
+        self.client.force_authenticate(user=self.applicant)
+        response = self.client.post(invalid_url, self.valid_payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_conditional_validation_fails(self) -> None:
+        """'스터디 경험' 필드 조건부 유효성 검사 실패 테스트"""
+        payload = self.valid_payload.copy()
+        payload["has_study_experience"] = True
+        # study_experience 필드를 보내지 않음
+
+        self.client.force_authenticate(user=self.applicant)
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("study_experience", response.data["message"])

--- a/apps/applications/urls/__init__.py
+++ b/apps/applications/urls/__init__.py
@@ -1,3 +1,3 @@
-from .author_urls import urlpatterns
+from .recruitments_uuid_urls import urlpatterns
 
 __all__ = ["urlpatterns"]

--- a/apps/applications/urls/__init__.py
+++ b/apps/applications/urls/__init__.py
@@ -1,0 +1,3 @@
+from .author_urls import urlpatterns
+
+__all__ = ["urlpatterns"]

--- a/apps/applications/urls/author_urls.py
+++ b/apps/applications/urls/author_urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from ..application_views import ApplicationAPIView
+
+urlpatterns = [
+    # name="application-create"는 Django 내에서 이 URL 경로에 대한 별칭을 지정하는 것으로,
+    # 나중에 reverse() 함수 등을 통해 이 이름으로 URL을 쉽게 찾을 수 있다.
+    path("/recruitments/<uuid:recruitment_uuid>/applications", ApplicationAPIView.as_view(), name="application-create"),
+]

--- a/apps/applications/urls/recruitments_uuid_urls.py
+++ b/apps/applications/urls/recruitments_uuid_urls.py
@@ -5,5 +5,6 @@ from ..application_views import ApplicationAPIView
 urlpatterns = [
     # name="application-create"는 Django 내에서 이 URL 경로에 대한 별칭을 지정하는 것으로,
     # 나중에 reverse() 함수 등을 통해 이 이름으로 URL을 쉽게 찾을 수 있다.
-    path("/recruitments/<uuid:recruitment_uuid>/applications", ApplicationAPIView.as_view(), name="application-create"),
+    # api/v1/recruitments/{recruitments_uuid}/application
+    path("", ApplicationAPIView.as_view(), name="application-create"),
 ]

--- a/apps/recruitments/urls/recruitments_urls.py
+++ b/apps/recruitments/urls/recruitments_urls.py
@@ -1,9 +1,13 @@
-from django.urls import path
+from django.urls import path, include
 
+from apps.applications.application_views import ApplicationAPIView
 from apps.recruitments.views.recruitments_views import RecruitmentDetailView
 from apps.recruitments.views.views_list import RecruitmentView
 
 urlpatterns = [
     path("", RecruitmentView.as_view(), name="recruitment-list"),
     path("/<uuid:recruitment_uuid>", RecruitmentDetailView.as_view(), name="recruitment-detail"),
+
+    # application - endpoint prefix로 인해 여기서 처리
+    path("/<uuid:recruitment_uuid>/applications", include("apps.applications.urls.recruitments_uuid_urls")),
 ]

--- a/apps/recruitments/urls/recruitments_urls.py
+++ b/apps/recruitments/urls/recruitments_urls.py
@@ -1,4 +1,4 @@
-from django.urls import path, include
+from django.urls import include, path
 
 from apps.applications.application_views import ApplicationAPIView
 from apps.recruitments.views.recruitments_views import RecruitmentDetailView
@@ -7,7 +7,6 @@ from apps.recruitments.views.views_list import RecruitmentView
 urlpatterns = [
     path("", RecruitmentView.as_view(), name="recruitment-list"),
     path("/<uuid:recruitment_uuid>", RecruitmentDetailView.as_view(), name="recruitment-detail"),
-
     # application - endpoint prefix로 인해 여기서 처리
     path("/<uuid:recruitment_uuid>/applications", include("apps.applications.urls.recruitments_uuid_urls")),
 ]


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #85 
- 작업 요약: 공고 참여 기능 구현

## 📄 상세 내용
- [ ] 한 명의 사용자가 동일한 공고에 두 번 이상 지원할 수 없도록 제한합니다.
- [ ] 사용자가 POST /api/v1/recruitments/{uuid}/application 엔드포인트로 지원서 데이터를 전송하면, 새로운 Application 객체를 새엇ㅇ, 데이터베이스에 저장합니다.
- [ ] 지원서의 '스터디 경험 유무' 필드가 True일 경우에만 '구체적인 스터디 경험' 필드 작성을 강제합니다.
- [ ] 유효하지 않은 공고 uuid로 요청이 들어올 경우, 작업을 중단하고 에러를 반환합니다.
- [ ] 테스트 코드 작성 및 안정성 향상 : 테스트 실행 시 User 및 Recruitments 모델의 필수 필드 누락으로 발생하는 IntegrityError와, 시간대 정보 누락으로 발생하는 RuntimeWarning을 해결했습니다.
- [ ] isort, black을 실행하고 mypy, coverage run/report모두 통과했습니다.

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
