### PR TITLE
공고 신청, 승인, 거절 알림 생성 로직 구현

### DIFF
--- a/apps/notifications/apps.py
+++ b/apps/notifications/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class NotificationsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "apps.notifications"
+
+    def ready(self) -> None:
+        from . import receivers

--- a/apps/notifications/receivers.py
+++ b/apps/notifications/receivers.py
@@ -1,13 +1,27 @@
-from typing import Any
+from typing import Any, Optional
 
 from django.db import transaction
-from django.db.models.signals import post_save
+from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 
 from apps.applications.models import Application
 from apps.notifications.services.noti_create_service import (
     NotificationCreateApplicationService,
 )
+
+
+@receiver(pre_save, sender=Application, dispatch_uid="application_track_prev_status")  # 이전 status / pre_save = 저장되기 전
+def prev_status(instance: Application, **kwargs: Any) -> None:
+    if not instance.pk: # 새로 만드는 객체라면 이전 상태 없음
+        prev: Optional[str] = None
+    else: # 이미 DB에 있던 객체라면 저장되어 있던 이전 status를 읽어와 prev에 넣음
+        prev = (
+            Application.objects
+            .filter(pk=instance.pk)
+            .values_list("status", flat=True)
+            .first()
+        )
+    setattr(instance, "status_was", prev)
 
 
 @receiver(post_save, sender=Application, dispatch_uid="notify_add_application")
@@ -21,3 +35,30 @@ def notify_add_application(instance: Application, created: bool, **kwargs: Any) 
         NotificationCreateApplicationService.notification_add_application_by_id(app_id)
 
     transaction.on_commit(add_application)
+
+
+@receiver(post_save, sender=Application, dispatch_uid="notify_status_change_to_applicant")
+def notify_status_change_to_applicant(instance: Application, created: bool, **kwargs: Any) -> None:
+    if created: # 신규 생성이 아닌 업데이트 하는거기에
+        return
+
+    app_id = instance.pk
+    prev: Optional[str] = getattr(instance, "status_was", None) # pre_save 때 붙여둔 임시 속성을 꺼내옴
+    curr = instance.status # 현재 상태
+
+    if prev == curr: # 이전과 현재가 같을 경우 X
+        return
+
+    if curr == Application.ApplicationStatus.ACCEPTED: # 현재가 승인  상태로 바뀐 경우만
+
+        def accept_application() -> None:
+            NotificationCreateApplicationService.notification_application_accept_by_id(app_id)
+
+        transaction.on_commit(accept_application)
+
+    if curr == Application.ApplicationStatus.REJECTED:
+
+        def reject_application() -> None:
+            NotificationCreateApplicationService.notification_application_reject_by_id(app_id)
+
+        transaction.on_commit(reject_application)

--- a/apps/notifications/receivers.py
+++ b/apps/notifications/receivers.py
@@ -10,17 +10,14 @@ from apps.notifications.services.noti_create_service import (
 )
 
 
-@receiver(pre_save, sender=Application, dispatch_uid="application_track_prev_status")  # 이전 status / pre_save = 저장되기 전
+@receiver(
+    pre_save, sender=Application, dispatch_uid="application_track_prev_status"
+)  # 이전 status / pre_save = 저장되기 전
 def prev_status(instance: Application, **kwargs: Any) -> None:
-    if not instance.pk: # 새로 만드는 객체라면 이전 상태 없음
+    if not instance.pk:  # 새로 만드는 객체라면 이전 상태 없음
         prev: Optional[str] = None
-    else: # 이미 DB에 있던 객체라면 저장되어 있던 이전 status를 읽어와 prev에 넣음
-        prev = (
-            Application.objects
-            .filter(pk=instance.pk)
-            .values_list("status", flat=True)
-            .first()
-        )
+    else:  # 이미 DB에 있던 객체라면 저장되어 있던 이전 status를 읽어와 prev에 넣음
+        prev = Application.objects.filter(pk=instance.pk).values_list("status", flat=True).first()
     setattr(instance, "status_was", prev)
 
 
@@ -39,17 +36,17 @@ def notify_add_application(instance: Application, created: bool, **kwargs: Any) 
 
 @receiver(post_save, sender=Application, dispatch_uid="notify_status_change_to_applicant")
 def notify_status_change_to_applicant(instance: Application, created: bool, **kwargs: Any) -> None:
-    if created: # 신규 생성이 아닌 업데이트 하는거기에
+    if created:  # 신규 생성이 아닌 업데이트 하는거기에
         return
 
     app_id = instance.pk
-    prev: Optional[str] = getattr(instance, "status_was", None) # pre_save 때 붙여둔 임시 속성을 꺼내옴
-    curr = instance.status # 현재 상태
+    prev: Optional[str] = getattr(instance, "status_was", None)  # pre_save 때 붙여둔 임시 속성을 꺼내옴
+    curr = instance.status  # 현재 상태
 
-    if prev == curr: # 이전과 현재가 같을 경우 X
+    if prev == curr:  # 이전과 현재가 같을 경우 X
         return
 
-    if curr == Application.ApplicationStatus.ACCEPTED: # 현재가 승인  상태로 바뀐 경우만
+    if curr == Application.ApplicationStatus.ACCEPTED:  # 현재가 승인  상태로 바뀐 경우만
 
         def accept_application() -> None:
             NotificationCreateApplicationService.notification_application_accept_by_id(app_id)

--- a/apps/notifications/receivers.py
+++ b/apps/notifications/receivers.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+from django.db import transaction
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from apps.applications.models import Application
+from apps.notifications.services.noti_create_service import (
+    NotificationCreateApplicationService,
+)
+
+
+@receiver(post_save, sender=Application, dispatch_uid="notify_add_application")
+def notify_add_application(instance: Application, created: bool, **kwargs: Any) -> None:
+    if not created:
+        return
+
+    app_id = instance.pk
+
+    def add_application() -> None:
+        NotificationCreateApplicationService.notification_add_application_by_id(app_id)
+
+    transaction.on_commit(add_application)

--- a/apps/notifications/services/noti_create_service.py
+++ b/apps/notifications/services/noti_create_service.py
@@ -3,6 +3,7 @@ from apps.notifications.models import Notification
 
 
 class NotificationCreateApplicationService:
+    # 공고 지원 시 알림
     @classmethod
     def notification_add_application_by_id(cls, app_id: int) -> Notification:  # N+1 방지를 위함
         app = Application.objects.select_related("recruitment__author", "recruitment", "user").get(pk=app_id)
@@ -19,4 +20,48 @@ class NotificationCreateApplicationService:
             content=f"{rec.title} 구인 공고에 신규 지원자가 있습니다.",
             notification_type=Notification.NotificationType.ADD_APPLICATION,
             back_url_link=f"/recruitments/{rec.uuid}/applications",
+        )
+
+    # 지원자에게 승인 알림
+    @classmethod
+    def notification_application_accept_by_id(cls, app_id: int) -> Notification:  # N+1 방지를 위함
+        app = Application.objects.select_related("recruitment__author", "recruitment", "user").get(pk=app_id)
+        return cls.notification_application_accept(app)
+
+    @classmethod
+    def notification_application_accept(cls, app: Application) -> Notification:
+        if app.status != Application.ApplicationStatus.ACCEPTED:
+            raise ValueError("Application status is not accepted")
+
+        rec = app.recruitment
+        if rec is None:
+            raise ValueError("Recruitment is None")
+
+        return Notification.objects.create(
+            user_id=app.user_id,
+            content=f"{rec.title} 구인 공고에 대한 지원 내역이 승인 되었습니다.",
+            notification_type=Notification.NotificationType.APPLICATION_ACCEPT,
+            back_url_link=f"/applications/me",
+        )
+
+    # 지원자에게 거절 알림
+    @classmethod
+    def notification_application_reject_by_id(cls, app_id: int) -> Notification:
+        app = Application.objects.select_related("recruitment__author", "recruitment", "user").get(pk=app_id)
+        return cls.notification_application_reject(app)
+
+    @classmethod
+    def notification_application_reject(cls, app: Application) -> Notification:
+        if app.status != Application.ApplicationStatus.REJECTED:
+            raise ValueError("Application.status is not REJECTED")
+
+        rec = app.recruitment
+        if rec is None:
+            raise ValueError("Application.recruitment is None")
+
+        return Notification.objects.create(
+            user_id=app.user_id,  # 수신자 = 지원자
+            content=f"{rec.title} 구인 공고에 대한 지원 내역이 거절되었습니다.",
+            notification_type=Notification.NotificationType.APPLICATION_REJECT,
+            back_url_link="/applications/me",
         )

--- a/apps/notifications/services/noti_create_service.py
+++ b/apps/notifications/services/noti_create_service.py
@@ -1,0 +1,22 @@
+from apps.applications.models.applications import Application
+from apps.notifications.models import Notification
+
+
+class NotificationCreateApplicationService:
+    @classmethod
+    def notification_add_application_by_id(cls, app_id: int) -> Notification:  # N+1 방지를 위함
+        app = Application.objects.select_related("recruitment__author", "recruitment", "user").get(pk=app_id)
+        return cls.notification_add_application(app)
+
+    @classmethod
+    def notification_add_application(cls, app: Application) -> Notification:
+        rec = app.recruitment
+        if rec is None:  # mypy
+            raise ValueError("Application.recruitment is None")
+
+        return Notification.objects.create(
+            user_id=rec.author_id,
+            content=f"{rec.title} 구인 공고에 신규 지원자가 있습니다.",
+            notification_type=Notification.NotificationType.ADD_APPLICATION,
+            back_url_link=f"/recruitments/{rec.uuid}/applications",
+        )

--- a/apps/notifications/tests/test_notification_create.py
+++ b/apps/notifications/tests/test_notification_create.py
@@ -68,7 +68,6 @@ class NotificationOnApplicationCreateTests(TransactionTestCase):
                 has_study_experience=True,
                 study_experience="학교 알고리즘 스터디",
                 status=Application.ApplicationStatus.PENDING,
-                created_at=timezone.now(),
             )
 
         # then: atomic 블록을 빠져나오면 on_commit 콜백이 실행됨
@@ -83,3 +82,82 @@ class NotificationOnApplicationCreateTests(TransactionTestCase):
         self.assertIn(self.recruitment.title, n.content)
 
         self.assertTrue(n.back_url_link.endswith(f"/recruitments/{self.recruitment.uuid}/applications"))
+
+    def test_notification_created_after_accept_status_change(self) -> None:
+        """
+        Application 상태가 PENDING -> ACCEPTED로 바뀌면
+        on_commit 이후 지원자에게 승인 알림이 생성되는지 검증
+        """
+        # PENDING으로 생성
+        with transaction.atomic():
+            app = Application.objects.create(
+                recruitment=self.recruitment,
+                user=self.applicant,
+                objective="파이썬 심화",
+                motivation="깊게 배우고 싶어서",
+                self_introduction="열심히 하겠습니다",
+                available_time="주중 저녁",
+                has_study_experience=False,
+                status=Application.ApplicationStatus.PENDING,
+            )
+
+        with transaction.atomic():
+            app.status = Application.ApplicationStatus.ACCEPTED
+            app.save(update_fields=["status"])
+
+        notifs = Notification.objects.filter(
+            user_id=self.applicant.id,
+            notification_type=Notification.NotificationType.APPLICATION_ACCEPT,
+        )
+        self.assertEqual(notifs.count(), 1)
+
+        n = notifs.first()
+        assert n is not None  # mypy
+        self.assertIn(self.recruitment.title, n.content)
+        self.assertEqual(n.back_url_link, "/applications/me")
+
+        # 같은 상태로 한 번 더 저장해도 추가 생성되지 않음(중복 방지)
+        with transaction.atomic():
+            app.status = Application.ApplicationStatus.ACCEPTED
+            app.save(update_fields=["status"])
+        self.assertEqual(notifs.count(), 1)
+
+    def test_notification_created_after_reject_status_change(self) -> None:
+        """
+        Application 상태가 PENDING -> REJECTED로 바뀌면
+        on_commit 이후 지원자에게 거절 알림이 생성되는지 검증
+        """
+        # PENDING으로 생성
+        with transaction.atomic():
+            app = Application.objects.create(
+                recruitment=self.recruitment,
+                user=self.applicant,
+                objective="파이썬 심화",
+                motivation="깊게 배우고 싶어서",
+                self_introduction="열심히 하겠습니다",
+                available_time="주중 저녁",
+                has_study_experience=False,
+                status=Application.ApplicationStatus.PENDING,
+            )
+
+        # 상태를 REJECTED로 변경 (created=False)
+        with transaction.atomic():
+            app.status = Application.ApplicationStatus.REJECTED
+            app.save(update_fields=["status"])
+
+        # 지원자에게 거절 알림 1건 생성
+        notifs = Notification.objects.filter(
+            user_id=self.applicant.id,
+            notification_type=Notification.NotificationType.APPLICATION_REJECT,
+        )
+        self.assertEqual(notifs.count(), 1)
+        n = notifs.first()
+        assert n is not None
+        self.assertIn(self.recruitment.title, n.content)
+        self.assertEqual(n.back_url_link, "/applications/me")
+
+        # 같은 상태로 한 번 더 저장해도 추가 생성되지 않음(중복 방지)
+        with transaction.atomic():
+            app.status = Application.ApplicationStatus.REJECTED
+            app.save(update_fields=["status"])
+        self.assertEqual(notifs.count(), 1)

--- a/apps/notifications/tests/test_notification_create.py
+++ b/apps/notifications/tests/test_notification_create.py
@@ -1,0 +1,85 @@
+from datetime import date, timedelta
+
+from django.db import transaction
+from django.test import TransactionTestCase
+from django.utils import timezone
+
+from apps.applications.models.applications import Application
+from apps.notifications.models import Notification
+from apps.recruitments.models.recruitments import Recruitment
+from apps.studies.models.study_groups import StudyGroup
+from apps.users.models.user import User
+
+
+class NotificationOnApplicationCreateTests(TransactionTestCase):
+    """
+    Application 생성(post_save, created=True) 시
+    on_commit 이후 Notification이 생성되는지 검증
+    """
+
+    def setUp(self) -> None:
+        # 작성자와 지원자
+        self.leader = User.objects.create_user(
+            email="leader@example.com",
+            password="pass1234!",
+            nickname="leader",
+            name="Leader",
+            phone_number="01000000000",
+            gender="male",
+            birthday=date(1990, 1, 1),
+        )
+        self.applicant = User.objects.create_user(
+            email="applicant@example.com",
+            password="pass1234!",
+            nickname="applicant",
+            name="Applicant",
+            phone_number="01011111111",
+            gender="male",
+            birthday=date(1995, 1, 1),
+        )
+        now = timezone.now()
+        study_group = StudyGroup.objects.create(
+            name="Study", max_headcount=10, start_at=now, end_at=now + timedelta(days=30)
+        )
+        self.recruitment = Recruitment.objects.create(
+            study_group=study_group,
+            author=self.leader,
+            title="API 테스트용 공고",
+            content="테스트 내용",
+            expected_headcount=5,
+            estimated_fee=25000,
+            views_count=100,
+        )
+
+    def test_notification_created_after_application_save_commit(self) -> None:
+        """
+        Application 생성 시 on_commit 이후 Notification 1건이 생성되고,
+        수신자/타입/콘텐츠/링크가 기대값인지 검증
+        """
+        # when: Application 생성 (created=True)
+        with transaction.atomic():
+            app = Application.objects.create(
+                recruitment=self.recruitment,
+                user=self.applicant,
+                objective="파이썬 심화",
+                motivation="깊게 배우고 싶어서",
+                self_introduction="열심히 하겠습니다",
+                available_time="주중 저녁",
+                has_study_experience=True,
+                study_experience="학교 알고리즘 스터디",
+                status=Application.ApplicationStatus.PENDING,
+                created_at=timezone.now(),
+            )
+
+        # then: atomic 블록을 빠져나오면 on_commit 콜백이 실행됨
+        notifs = Notification.objects.filter(
+            user_id=self.leader.id,
+            notification_type=Notification.NotificationType.ADD_APPLICATION,
+        )
+        self.assertEqual(notifs.count(), 1)
+
+        n = notifs.first()
+        assert n is not None  # mypy
+        self.assertIn(self.recruitment.title, n.content)
+
+        self.assertTrue(n.back_url_link.endswith(f"/recruitments/{self.recruitment.uuid}/applications"))


### PR DESCRIPTION

## ✅ PR 요약
- 관련 이슈 번호: #103
- 작업 요약: 리시버 및 서비스에서 알림생성 구현, 관련 테스트 코드 작성

## 📄 상세 내용
- [x] Application 모델에 DB저장 시 post_save를 감지하는 리시버 생성
- [x] 서비스 레이어에 공고 지원시 발생하는 알림 생성 로직 구현
- [x] 관련 테스트 코드 작성

## 📸 스크린샷 (선택)
<img width="1379" height="570" alt="스크린샷 2025-09-14 오후 6 27 35" src="https://github.com/user-attachments/assets/38622761-19c9-4a46-bb23-13226ab512b6" />

## 📝 기타 참고 사항
비동기 백그라운 테스크 및 sse 연동은 추후 구현 예정

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
