### PR TITLE
feat :리뷰 목록 조회 API 구현 (테스트 커버리지 100%)

### DIFF
--- a/apps/studies/serializers/review_serializers.py
+++ b/apps/studies/serializers/review_serializers.py
@@ -68,24 +68,6 @@ class ReviewCreateResponseSerializer(serializers.ModelSerializer[StudyReview]):
         read_only_fields = ["id", "user_id", "study_group_id", "created_at"]
 
 
-class ReviewListRequestSerializer(serializers.Serializer[Dict[str, Any]]):
-    """
-    스터디 그룹 리뷰 목록 조회 요청 전용 Serializer
-    """
-
-    group_uuid = serializers.UUIDField()
-
-    def validate_group_uuid(self, value: Any) -> Any:
-        # group_uuid가 유효한 StudyGroup인지 검증, 없으면 404 반환
-        try:
-            group = StudyGroup.objects.get(uuid=value)
-        except StudyGroup.DoesNotExist as exc:
-            raise NotFound(detail="해당 스터디 그룹이 존재하지 않습니다.") from exc
-
-        self.context["study_group"] = group
-        return value
-
-
 class ReviewListItemSerializer(serializers.ModelSerializer[StudyReview]):
     """
     스터디 그룹 리뷰 목록의 개별 응답 Serializer
@@ -97,12 +79,12 @@ class ReviewListItemSerializer(serializers.ModelSerializer[StudyReview]):
         model = StudyReview
         fields = ["rating", "content", "created_at"]
 
-    def get_rating(self, obj: StudyReview) -> str:
+    def get_rating(self, obj: Any) -> str:
         # star_rating을 "N_OUT_OF_5_STARS" 포맷으로 변환
         return f"{int(obj.star_rating)}_OUT_OF_5_STARS"
 
 
-class ReviewListResponseSerializer(serializers.Serializer[Dict[str, Any]]):
+class ReviewListResponseSerializer(serializers.Serializer[dict[str, object]]):
     """
     스터디 그룹 리뷰 목록 응답 Envelope Serializer
     """

--- a/apps/studies/serializers/review_serializers.py
+++ b/apps/studies/serializers/review_serializers.py
@@ -1,8 +1,10 @@
 from typing import Any, Dict
-from rest_framework.exceptions import NotFound, ValidationError
-from rest_framework import serializers
-from rest_framework.validators import UniqueTogetherValidator
+
 from django.db.models import QuerySet
+from rest_framework import serializers
+from rest_framework.exceptions import NotFound, ValidationError
+from rest_framework.validators import UniqueTogetherValidator
+
 from apps.studies.models.study_groups import StudyGroup
 from apps.studies.models.study_reviews import StudyReview
 from apps.users.models.user import User

--- a/apps/studies/serializers/review_serializers.py
+++ b/apps/studies/serializers/review_serializers.py
@@ -85,20 +85,6 @@ class ReviewListRequestSerializer(serializers.Serializer[Dict[str, Any]]):
         self.context["study_group"] = group
         return value
 
-    def get_queryset(self) -> QuerySet[StudyReview]:
-        # 검증된 StudyGroup에 속한 리뷰 목록을 최신순으로 조회, 없으면 404 반환
-        group: StudyGroup = self.context["study_group"]
-        qs = StudyReview.objects.filter(study_group=group).order_by("-created_at")
-        if not qs.exists():
-            raise NotFound("해당 스터디 그룹에 대한 리뷰가 존재하지 않습니다.")
-        return qs
-
-    def build_payload(self) -> Dict[str, Any]:
-        # 응답에 필요한 데이터(study_group_id, reviews) 구성
-        group: StudyGroup = self.context["study_group"]
-        reviews = self.get_queryset()
-        return {"study_group_id": group.id, "reviews": reviews}
-
 
 class ReviewListItemSerializer(serializers.ModelSerializer[StudyReview]):
     """

--- a/apps/studies/serializers/review_serializers.py
+++ b/apps/studies/serializers/review_serializers.py
@@ -17,38 +17,19 @@ class ReviewCreateRequestSerializer(serializers.ModelSerializer[StudyReview]):
     - 클라이언트가 보내는 값만 포함
     """
 
-    study_group_id = serializers.PrimaryKeyRelatedField(
-        queryset=StudyGroup.objects.all(),
-        source="study_group",
-        write_only=True,
-    )
-    rating = serializers.ChoiceField(
+    star_rating = serializers.ChoiceField(
         choices=StudyReview.RatingEnum.choices,
-        source="star_rating",
         write_only=True,
     )
-
-    # 내부 Hidden 필드
-    user = serializers.HiddenField(default=serializers.CurrentUserDefault())
 
     class Meta:
         model = StudyReview
-        fields = ["user", "study_group_id", "rating", "content"]
+        fields = ["star_rating", "content"]
 
-        extra_kwargs = {"content": {"write_only": True}}
-        validators = [
-            UniqueTogetherValidator(
-                queryset=StudyReview.objects.all(),
-                fields=["user", "study_group_id"],
-                message="이미 리뷰를 작성한 스터디 그룹입니다.",
-            )
-        ]
-
-    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
-        study_group = attrs["study_group"]
-        if study_group.status != StudyGroup.StatusChoices.ENDED:
-            raise serializers.ValidationError({"detail": "종료되지 않은 스터디 그룹에는 리뷰를 작성할 수 없습니다."})
-        return attrs
+        extra_kwargs = {
+            "content": {"write_only": True},
+            "star_rating": {"write_only": True},
+        }
 
 
 # 응답 전용 Serializer
@@ -58,36 +39,21 @@ class ReviewCreateResponseSerializer(serializers.ModelSerializer[StudyReview]):
     - 서버가 클라이언트에게 돌려주는 값만 포함
     """
 
-    user_id = serializers.IntegerField(source="user.id", read_only=True)
-    study_group_id = serializers.IntegerField(source="study_group.id", read_only=True)
-    rating = serializers.IntegerField(source="star_rating")
+    study_group_uuid = serializers.IntegerField(source="study_group.uuid")
 
     class Meta:
         model = StudyReview
-        fields = ["id", "user_id", "study_group_id", "rating", "content", "created_at"]
-        read_only_fields = ["id", "user_id", "study_group_id", "created_at"]
+        fields = ["id", "user_id", "study_group_uuid", "star_rating", "content", "created_at"]
+        read_only_fields = fields
 
 
-class ReviewListItemSerializer(serializers.ModelSerializer[StudyReview]):
+class ReviewListResponseSerializer(serializers.ModelSerializer[StudyReview]):
     """
     스터디 그룹 리뷰 목록의 개별 응답 Serializer
     """
 
-    rating = serializers.SerializerMethodField()
+    study_group_uuid = serializers.UUIDField(source="study_group.uuid", read_only=True)
 
     class Meta:
         model = StudyReview
-        fields = ["rating", "content", "created_at"]
-
-    def get_rating(self, obj: Any) -> str:
-        # star_rating을 "N_OUT_OF_5_STARS" 포맷으로 변환
-        return f"{int(obj.star_rating)}_OUT_OF_5_STARS"
-
-
-class ReviewListResponseSerializer(serializers.Serializer[dict[str, object]]):
-    """
-    스터디 그룹 리뷰 목록 응답 Envelope Serializer
-    """
-
-    study_group_id = serializers.IntegerField()
-    reviews = ReviewListItemSerializer(many=True)
+        fields = ["study_group_uuid", "star_rating", "content", "created_at"]

--- a/apps/studies/serializers/review_serializers.py
+++ b/apps/studies/serializers/review_serializers.py
@@ -1,8 +1,8 @@
-from typing import Any
-
+from typing import Any, Dict
+from rest_framework.exceptions import NotFound, ValidationError
 from rest_framework import serializers
 from rest_framework.validators import UniqueTogetherValidator
-
+from django.db.models import QuerySet
 from apps.studies.models.study_groups import StudyGroup
 from apps.studies.models.study_reviews import StudyReview
 from apps.users.models.user import User
@@ -64,3 +64,60 @@ class ReviewCreateResponseSerializer(serializers.ModelSerializer[StudyReview]):
         model = StudyReview
         fields = ["id", "user_id", "study_group_id", "rating", "content", "created_at"]
         read_only_fields = ["id", "user_id", "study_group_id", "created_at"]
+
+
+class ReviewListRequestSerializer(serializers.Serializer[Dict[str, Any]]):
+    """
+    스터디 그룹 리뷰 목록 조회 요청 전용 Serializer
+    """
+
+    group_uuid = serializers.UUIDField()
+
+    def validate_group_uuid(self, value: Any) -> Any:
+        # group_uuid가 유효한 StudyGroup인지 검증, 없으면 404 반환
+        try:
+            group = StudyGroup.objects.get(uuid=value)
+        except StudyGroup.DoesNotExist as exc:
+            raise NotFound(detail="해당 스터디 그룹이 존재하지 않습니다.") from exc
+
+        self.context["study_group"] = group
+        return value
+
+    def get_queryset(self) -> QuerySet[StudyReview]:
+        # 검증된 StudyGroup에 속한 리뷰 목록을 최신순으로 조회, 없으면 404 반환
+        group: StudyGroup = self.context["study_group"]
+        qs = StudyReview.objects.filter(study_group=group).order_by("-created_at")
+        if not qs.exists():
+            raise NotFound("해당 스터디 그룹에 대한 리뷰가 존재하지 않습니다.")
+        return qs
+
+    def build_payload(self) -> Dict[str, Any]:
+        # 응답에 필요한 데이터(study_group_id, reviews) 구성
+        group: StudyGroup = self.context["study_group"]
+        reviews = self.get_queryset()
+        return {"study_group_id": group.id, "reviews": reviews}
+
+
+class ReviewListItemSerializer(serializers.ModelSerializer[StudyReview]):
+    """
+    스터디 그룹 리뷰 목록의 개별 응답 Serializer
+    """
+
+    rating = serializers.SerializerMethodField()
+
+    class Meta:
+        model = StudyReview
+        fields = ["rating", "content", "created_at"]
+
+    def get_rating(self, obj: StudyReview) -> str:
+        # star_rating을 "N_OUT_OF_5_STARS" 포맷으로 변환
+        return f"{int(obj.star_rating)}_OUT_OF_5_STARS"
+
+
+class ReviewListResponseSerializer(serializers.Serializer[Dict[str, Any]]):
+    """
+    스터디 그룹 리뷰 목록 응답 Envelope Serializer
+    """
+
+    study_group_id = serializers.IntegerField()
+    reviews = ReviewListItemSerializer(many=True)

--- a/apps/studies/tests/test_reviews.py
+++ b/apps/studies/tests/test_reviews.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.utils import timezone
+from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
 from apps.studies.models import StudyGroup, StudyReview
@@ -120,3 +121,95 @@ class TestStudyReviewCreateAPI(APITestCase):
         # 수정: "detail" 키와 메시지 내용 확인
         self.assertIn("detail", response.data)
         self.assertIn("종료되지 않은 스터디 그룹에는 리뷰를 작성할 수 없습니다.", response.data["detail"])
+
+
+class TestStudyGroupReviewListAPI(APITestCase):
+    """
+    [REQ-REVW-00] 스터디 그룹 리뷰 목록 조회 API
+
+    검증 포인트
+    - 성공: 200 OK + 응답 구조/필드/포맷
+    - 실패: 리뷰 없음 -> 404 Bad Request
+    - 실패: 잘못된 group_uuid -> 404 Not Found
+    - 실패: 비인증 -> 401 Unauthorized
+    """
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.user = User.objects.create_user(
+            email="test@test.com",
+            password="1234",
+            birthday="2000-01-01",
+            name="테스트유저",
+            nickname="tester",
+            phone_number="01000000001",
+        )
+        self.study_group = StudyGroup.objects.create(
+            name="테스트 그룹",
+            introduction="소개",
+            max_headcount=5,
+            start_at=timezone.now() - timedelta(days=10),
+            end_at=timezone.now() - timedelta(days=1),
+            status=StudyGroup.StatusChoices.ENDED,
+        )
+        self.url = reverse("study-group-review-list", kwargs={"group_uuid": self.study_group.uuid})
+
+    def test_success_review_list(self) -> None:
+        # 성공 케이스: 스터디 그룹 리뷰 목록 조회
+        self.client.force_authenticate(self.user)
+
+        # 첫 번째 리뷰 (기본 self.user)
+        StudyReview.objects.create(
+            user=self.user,
+            study_group=self.study_group,
+            content="정말 유익한 스터디였습니다.",
+            star_rating=5,
+        )
+
+        # 두 번째 리뷰
+        user2 = User.objects.create_user(
+            email="other@test.com",
+            password="1234",
+            name="다른유저",
+            nickname="other",
+            birthday="2001-01-01",
+            phone_number="01000000002",
+        )
+        StudyReview.objects.create(
+            user=user2,
+            study_group=self.study_group,
+            content="좋았지만 시간이 조금 촉박했어요.",
+            star_rating=4,
+        )
+
+        resp = self.client.get(self.url, format="json")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertIn("reviews", resp.data)
+        self.assertEqual(len(resp.data["reviews"]), 2)
+
+    def test_fail_review_list_no_reviews(self) -> None:
+        # 실패: 리뷰가 없는 경우 (400)
+        # - detail 메시지가 명세서와 정확히 일치해야 한다.
+        self.client.force_authenticate(self.user)
+
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertIn("detail", resp.data)
+        self.assertEqual(resp.data["detail"], "해당 스터디 그룹에 대한 리뷰가 존재하지 않습니다.")
+
+    def test_fail_review_list_invalid_uuid(self) -> None:
+        # 실패: 존재하지 않는 그룹 uuid (404)
+        self.client.force_authenticate(self.user)
+
+        bad_url = reverse(
+            "study-group-review-list",
+            kwargs={"group_uuid": "11111111-1111-1111-1111-111111111111"},
+        )
+        resp = self.client.get(bad_url)
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_fail_review_list_unauthenticated(self) -> None:
+        # 실패: 비인증 사용자 (401)
+        resp = self.client.get(self.url)
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/apps/studies/tests/test_reviews.py
+++ b/apps/studies/tests/test_reviews.py
@@ -1,14 +1,13 @@
+import uuid
 from datetime import timedelta
 
-from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
 from apps.studies.models import StudyGroup, StudyReview
-
-User = get_user_model()
+from apps.users.models.user import User
 
 
 class TestStudyReviewCreateAPI(APITestCase):
@@ -18,7 +17,7 @@ class TestStudyReviewCreateAPI(APITestCase):
     """
 
     def setUp(self) -> None:
-        self.client = APIClient()
+        self.client = self.client_class()
         self.user = User.objects.create_user(
             email="test@test.com", password="1234", birthday="2000-01-01", name="테스트유저", nickname="tester"
         )
@@ -33,13 +32,12 @@ class TestStudyReviewCreateAPI(APITestCase):
             end_at=timezone.now() - timedelta(days=1),
             status=StudyGroup.StatusChoices.ENDED,
         )
-        self.url = reverse("review-create")
+        self.url = reverse("review-create-list", kwargs={"group_uuid": self.study_group.uuid})
 
     def test_create_review_success(self) -> None:
         # 성공 케이스
         data = {
-            "study_group_id": self.study_group.id,
-            "rating": 5,
+            "star_rating": 5,
             "content": "정말 유익한 스터디였습니다!",
         }
         response = self.client.post(self.url, data, format="json")
@@ -50,23 +48,23 @@ class TestStudyReviewCreateAPI(APITestCase):
 
     def test_create_review_unauthenticated(self) -> None:
         # 실패: 비로그인
-        client = APIClient()
-        data = {"study_group_id": self.study_group.id, "rating": 5, "content": "로그인 안 했어요"}
-        response = client.post(self.url, data, format="json")
+        self.client.logout()
+        data = {"star_rating": 5, "content": "로그인 안 했어요"}
+        response = self.client.post(self.url, data, format="json")
         self.assertEqual(response.status_code, 401)
 
     def test_create_review_duplicate(self) -> None:
         # 실패: 중복 리뷰
         StudyReview.objects.create(user=self.user, study_group=self.study_group, star_rating=5, content="첫 리뷰")
-        data = {"study_group_id": self.study_group.id, "rating": 5, "content": "중복 리뷰 시도"}
+        data = {"star_rating": 5, "content": "중복 리뷰 시도"}
         response = self.client.post(self.url, data, format="json")
 
         self.assertEqual(response.status_code, 400)
-        self.assertIn("이미 리뷰를 작성한", str(response.data))
+        self.assertIn("이미 작성된 리뷰가 있습니다.", str(response.data))
 
-    def test_create_review_invalid_rating(self) -> None:
+    def test_create_review_invalid_star_rating(self) -> None:
         # 실패: 잘못된 평점 일부러 존재하지않는 점수 부여함 ㅋ
-        data = {"study_group_id": self.study_group.id, "rating": 10, "content": "잘못된 평점"}
+        data = {"star_rating": 10, "content": "잘못된 평점"}
         response = self.client.post(self.url, data, format="json")
         self.assertEqual(response.status_code, 400)
 
@@ -80,23 +78,12 @@ class TestStudyReviewCreateAPI(APITestCase):
             end_at=timezone.now() + timedelta(days=7),
             status=StudyGroup.StatusChoices.ONGOING,
         )
-        data = {"study_group_id": active_group.id, "rating": 5, "content": "아직 끝나지 않았어요"}
+        self.url = reverse("review-create-list", kwargs={"group_uuid": active_group.uuid})
+        data = {"star_rating": 5, "content": "아직 끝나지 않았어요"}
         response = self.client.post(self.url, data, format="json")
 
         self.assertEqual(response.status_code, 400)
         self.assertIn("종료되지 않은", str(response.data))
-
-    def test_create_review_triggers_create_method(self) -> None:
-        # 성공 케이스에서 create() 메서드까지 실행 확인
-        data = {"study_group_id": self.study_group.id, "rating": 4, "content": "create 메서드 확인"}
-        response = self.client.post(self.url, data, format="json")
-
-        self.assertEqual(response.status_code, 201)
-        review = StudyReview.objects.first()
-        assert review is not None  # mypy 통과용
-
-        self.assertEqual(review.user, self.user)
-        self.assertEqual(review.star_rating, 4)
 
     def test_create_review_exact_error_messages(self) -> None:
         # 실패 케이스에서 ValidationError 메시지 구조까지 검증
@@ -108,19 +95,27 @@ class TestStudyReviewCreateAPI(APITestCase):
             end_at=timezone.now() + timedelta(days=5),
             status=StudyGroup.StatusChoices.ONGOING,
         )
+        self.url = reverse("review-create-list", kwargs={"group_uuid": active_group.uuid})
         data = {
-            "study_group_id": active_group.id,
-            "rating": 5,
+            "star_rating": 5,
             "content": "에러 메시지 확인",
         }
         response = self.client.post(self.url, data, format="json")
 
         self.assertEqual(response.status_code, 400)
 
-        # 기존: self.assertIn("study_group_id", response.data)
-        # 수정: "detail" 키와 메시지 내용 확인
-        self.assertIn("detail", response.data)
-        self.assertIn("종료되지 않은 스터디 그룹에는 리뷰를 작성할 수 없습니다.", response.data["detail"])
+        # "error" 키와 메시지 내용 확인
+        self.assertIn("error", response.data)
+        self.assertIn("종료되지 않은 스터디 그룹에는 리뷰를 작성할 수 없습니다.", response.data["error"])
+
+    def test_create_review_when_invalid_group_uuid(self) -> None:
+        self.invalid_url = reverse("review-create-list", kwargs={"group_uuid": (uuid_val := uuid.uuid4())})
+        data = {
+            "star_rating": 5,
+            "content": "에러 메시지 확인",
+        }
+        response = self.client.post(self.invalid_url, data, format="json")
+        self.assertEqual(response.status_code, 400)
 
 
 class TestStudyGroupReviewListAPI(APITestCase):
@@ -129,13 +124,13 @@ class TestStudyGroupReviewListAPI(APITestCase):
 
     검증 포인트
     - 성공: 200 OK + 응답 구조/필드/포맷
-    - 성공: 리뷰 없음 -> 200 OK + 빈 리스트 (study_group_id 없음)
+    - 성공: 리뷰 없음 -> 200 OK + 빈 리스트 (study_group_uuid 포함)
     - 실패: 잘못된 group_uuid -> 404 Not Found
     - 실패: 비인증 -> 401 Unauthorized
     """
 
     def setUp(self) -> None:
-        self.client = APIClient()
+        self.client = self.client_class()
         self.user = User.objects.create_user(
             email="test@test.com",
             password="1234",
@@ -152,12 +147,10 @@ class TestStudyGroupReviewListAPI(APITestCase):
             end_at=timezone.now() - timedelta(days=1),
             status=StudyGroup.StatusChoices.ENDED,
         )
-        self.url = reverse("study-group-review-list", kwargs={"group_uuid": self.study_group.uuid})
+        self.url = reverse("review-create-list", kwargs={"group_uuid": self.study_group.uuid})
 
     def test_success_review_list(self) -> None:
         # 성공 케이스: 스터디 그룹 리뷰 목록 조회
-        self.client.force_authenticate(self.user)
-
         StudyReview.objects.create(
             user=self.user,
             study_group=self.study_group,
@@ -183,33 +176,21 @@ class TestStudyGroupReviewListAPI(APITestCase):
         resp = self.client.get(self.url, format="json")
 
         self.assertEqual(resp.status_code, 200)
-        self.assertIn("reviews", resp.data)
-        self.assertEqual(len(resp.data["reviews"]), 2)
-        self.assertIn("study_group_id", resp.data)
+        self.assertEqual(len(resp.data), 2)
+        self.assertIn("study_group_uuid", resp.data[0])
+        self.assertEqual(resp.data[0]["study_group_uuid"], str(self.study_group.uuid))
 
     def test_success_review_list_no_reviews(self) -> None:
-        # 성공: 리뷰가 없는 경우 -> 200 OK + 빈 리스트 (study_group_id 포함)
-        self.client.force_authenticate(self.user)
-
+        # 성공: 리뷰가 없는 경우 -> 200 OK + 빈 리스트 (study_group_uuid 포함)
         resp = self.client.get(self.url)
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
-        self.assertIn("reviews", resp.data)
-        self.assertEqual(len(resp.data["reviews"]), 0)
-        self.assertIn("study_group_id", resp.data)
-        self.assertEqual(resp.data["study_group_id"], self.study_group.id)
+        self.assertEqual(len(resp.data), 0)
 
     def test_fail_review_list_invalid_uuid(self) -> None:
         # 실패: 존재하지 않는 그룹 uuid (404)
-        self.client.force_authenticate(self.user)
-
         bad_url = reverse(
-            "study-group-review-list",
+            "review-create-list",
             kwargs={"group_uuid": "11111111-1111-1111-1111-111111111111"},
         )
         resp = self.client.get(bad_url)
-        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
-
-    def test_fail_review_list_unauthenticated(self) -> None:
-        # 실패: 비인증 사용자 (401)
-        resp = self.client.get(self.url)
-        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)

--- a/apps/studies/tests/test_reviews.py
+++ b/apps/studies/tests/test_reviews.py
@@ -129,7 +129,7 @@ class TestStudyGroupReviewListAPI(APITestCase):
 
     검증 포인트
     - 성공: 200 OK + 응답 구조/필드/포맷
-    - 성공: 리뷰 없음 -> 200 OK + 빈 리스트
+    - 성공: 리뷰 없음 -> 200 OK + 빈 리스트 (study_group_id 없음)
     - 실패: 잘못된 group_uuid -> 404 Not Found
     - 실패: 비인증 -> 401 Unauthorized
     """
@@ -185,15 +185,18 @@ class TestStudyGroupReviewListAPI(APITestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertIn("reviews", resp.data)
         self.assertEqual(len(resp.data["reviews"]), 2)
+        self.assertIn("study_group_id", resp.data)
 
     def test_success_review_list_no_reviews(self) -> None:
-        # 성공: 리뷰가 없는 경우 -> 200 OK + 빈 리스트
+        # 성공: 리뷰가 없는 경우 -> 200 OK + 빈 리스트 (study_group_id 포함)
         self.client.force_authenticate(self.user)
 
         resp = self.client.get(self.url)
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         self.assertIn("reviews", resp.data)
         self.assertEqual(len(resp.data["reviews"]), 0)
+        self.assertIn("study_group_id", resp.data)
+        self.assertEqual(resp.data["study_group_id"], self.study_group.id)
 
     def test_fail_review_list_invalid_uuid(self) -> None:
         # 실패: 존재하지 않는 그룹 uuid (404)

--- a/apps/studies/tests/test_reviews.py
+++ b/apps/studies/tests/test_reviews.py
@@ -129,7 +129,7 @@ class TestStudyGroupReviewListAPI(APITestCase):
 
     검증 포인트
     - 성공: 200 OK + 응답 구조/필드/포맷
-    - 실패: 리뷰 없음 -> 404 Bad Request
+    - 성공: 리뷰 없음 -> 200 OK + 빈 리스트
     - 실패: 잘못된 group_uuid -> 404 Not Found
     - 실패: 비인증 -> 401 Unauthorized
     """
@@ -158,7 +158,6 @@ class TestStudyGroupReviewListAPI(APITestCase):
         # 성공 케이스: 스터디 그룹 리뷰 목록 조회
         self.client.force_authenticate(self.user)
 
-        # 첫 번째 리뷰 (기본 self.user)
         StudyReview.objects.create(
             user=self.user,
             study_group=self.study_group,
@@ -166,7 +165,6 @@ class TestStudyGroupReviewListAPI(APITestCase):
             star_rating=5,
         )
 
-        # 두 번째 리뷰
         user2 = User.objects.create_user(
             email="other@test.com",
             password="1234",
@@ -188,15 +186,14 @@ class TestStudyGroupReviewListAPI(APITestCase):
         self.assertIn("reviews", resp.data)
         self.assertEqual(len(resp.data["reviews"]), 2)
 
-    def test_fail_review_list_no_reviews(self) -> None:
-        # 실패: 리뷰가 없는 경우 (400)
-        # - detail 메시지가 명세서와 정확히 일치해야 한다.
+    def test_success_review_list_no_reviews(self) -> None:
+        # 성공: 리뷰가 없는 경우 -> 200 OK + 빈 리스트
         self.client.force_authenticate(self.user)
 
         resp = self.client.get(self.url)
-        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertIn("detail", resp.data)
-        self.assertEqual(resp.data["detail"], "해당 스터디 그룹에 대한 리뷰가 존재하지 않습니다.")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertIn("reviews", resp.data)
+        self.assertEqual(len(resp.data["reviews"]), 0)
 
     def test_fail_review_list_invalid_uuid(self) -> None:
         # 실패: 존재하지 않는 그룹 uuid (404)

--- a/apps/studies/urls/review_urls.py
+++ b/apps/studies/urls/review_urls.py
@@ -1,7 +1,11 @@
 from django.urls import path
 
-from apps.studies.views.review_views import ReviewCreateAPIView
+from apps.studies.views.review_views import (
+    ReviewCreateAPIView,
+    StudyGroupReviewListView,
+)
 
 urlpatterns = [
     path("/reviews", ReviewCreateAPIView.as_view(), name="review-create"),
+    path("/reviews/<uuid:group_uuid>/", StudyGroupReviewListView.as_view(), name="study-group-review-list"),
 ]

--- a/apps/studies/urls/review_urls.py
+++ b/apps/studies/urls/review_urls.py
@@ -1,11 +1,8 @@
 from django.urls import path
 
-from apps.studies.views.review_views import (
-    ReviewCreateAPIView,
-    StudyGroupReviewListView,
-)
+from apps.studies.views.review_views import ReviewCreateListAPIView
 
 urlpatterns = [
-    path("/reviews", ReviewCreateAPIView.as_view(), name="review-create"),
-    path("/reviews/<uuid:group_uuid>/", StudyGroupReviewListView.as_view(), name="study-group-review-list"),
+    path("/<uuid:group_uuid>/reviews", ReviewCreateListAPIView.as_view(), name="review-create-list"),
+    # path("/<uuid:group_uuid>/reviews", name="study-group-review-list"),
 ]

--- a/apps/studies/views/review_views.py
+++ b/apps/studies/views/review_views.py
@@ -42,22 +42,25 @@ class StudyGroupReviewListView(APIView):
     """
     [REQ-REVW-00] 스터디 그룹 리뷰 목록 조회 API
     GET /api/v1/study-groups/reviews/{group_uuid}/
-    - 로그인한 사용자가 특정 스터디 그룹의 리뷰 목록을 조회한다.
     """
 
     permission_classes = [IsAuthenticated]
 
-    def get_queryset(self, group_uuid: UUID) -> Tuple[StudyGroup, "QuerySet[StudyReview]"]:
-        # 스터디 그룹 검증 (없으면 404)
-        group = get_object_or_404(StudyGroup, uuid=group_uuid)
-
-        # 리뷰 목록 조회 (없으면 빈 리스트 반환)
-        qs = StudyReview.objects.filter(study_group=group).order_by("-created_at")
-        return group, qs
+    def get_queryset(self, group_uuid: UUID) -> QuerySet[StudyReview]:
+        return StudyReview.objects.filter(study_group__uuid=group_uuid).order_by("-created_at")
 
     def get(self, request: Request, group_uuid: UUID, *args: object, **kwargs: object) -> Response:
-        group, qs = self.get_queryset(group_uuid)
-        payload = {"study_group_id": group.id, "reviews": qs}
+        qs = self.get_queryset(group_uuid)
 
+        study_group_id = qs.values_list("study_group_id", flat=True).first()
+
+        # 리뷰가 없으면 → StudyGroup 존재 여부 확인 후 id 가져오기
+        if study_group_id is None:
+            study_group_id = get_object_or_404(StudyGroup, uuid=group_uuid).id
+
+        payload = {
+            "study_group_id": study_group_id,
+            "reviews": qs,
+        }
         res = ReviewListResponseSerializer(payload, context={"request": request})
         return Response(res.data)

--- a/apps/studies/views/review_views.py
+++ b/apps/studies/views/review_views.py
@@ -1,12 +1,13 @@
 from uuid import UUID
 
 from rest_framework import status
-from rest_framework.exceptions import NotFound
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.studies.models.study_groups import StudyGroup
+from apps.studies.models.study_reviews import StudyReview
 from apps.studies.serializers.review_serializers import (
     ReviewCreateRequestSerializer,
     ReviewCreateResponseSerializer,
@@ -45,9 +46,14 @@ class StudyGroupReviewListView(APIView):
     permission_classes = [IsAuthenticated]
 
     def get(self, request: Request, group_uuid: UUID, *args: object, **kwargs: object) -> Response:
+        # 요청 검증
         req = ReviewListRequestSerializer(data={"group_uuid": group_uuid}, context={"request": request})
         req.is_valid(raise_exception=True)
 
-        payload = req.build_payload()  # 여기서 이미 404 처리됨
+        group: StudyGroup = req.context["study_group"]
+
+        qs = StudyReview.objects.filter(study_group=group).order_by("-created_at")
+        payload = {"study_group_id": group.id, "reviews": qs}
+
         res = ReviewListResponseSerializer(payload, context={"request": request})
         return Response(res.data)

--- a/apps/studies/views/review_views.py
+++ b/apps/studies/views/review_views.py
@@ -1,4 +1,8 @@
+from uuid import UUID
+
 from rest_framework import status
+from rest_framework.exceptions import NotFound
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -6,6 +10,8 @@ from rest_framework.views import APIView
 from apps.studies.serializers.review_serializers import (
     ReviewCreateRequestSerializer,
     ReviewCreateResponseSerializer,
+    ReviewListRequestSerializer,
+    ReviewListResponseSerializer,
 )
 
 
@@ -27,3 +33,21 @@ class ReviewCreateAPIView(APIView):
             return Response(response_serializer.data, status=status.HTTP_201_CREATED)
 
         return Response(request_serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class StudyGroupReviewListView(APIView):
+    """
+    [REQ-REVW-00] 스터디 그룹 리뷰 목록 조회 API
+    GET /api/v1/study-groups/reviews/{group_uuid}/
+    - 로그인한 사용자가 특정 스터디 그룹의 리뷰 목록을 조회한다.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request: Request, group_uuid: UUID, *args: object, **kwargs: object) -> Response:
+        req = ReviewListRequestSerializer(data={"group_uuid": group_uuid}, context={"request": request})
+        req.is_valid(raise_exception=True)
+
+        payload = req.build_payload()  # 여기서 이미 404 처리됨
+        res = ReviewListResponseSerializer(payload, context={"request": request})
+        return Response(res.data)

--- a/apps/studies/views/review_views.py
+++ b/apps/studies/views/review_views.py
@@ -1,5 +1,8 @@
+from typing import Tuple
 from uuid import UUID
 
+from django.db.models import QuerySet
+from django.shortcuts import get_object_or_404
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -11,7 +14,6 @@ from apps.studies.models.study_reviews import StudyReview
 from apps.studies.serializers.review_serializers import (
     ReviewCreateRequestSerializer,
     ReviewCreateResponseSerializer,
-    ReviewListRequestSerializer,
     ReviewListResponseSerializer,
 )
 
@@ -45,14 +47,16 @@ class StudyGroupReviewListView(APIView):
 
     permission_classes = [IsAuthenticated]
 
-    def get(self, request: Request, group_uuid: UUID, *args: object, **kwargs: object) -> Response:
-        # 요청 검증
-        req = ReviewListRequestSerializer(data={"group_uuid": group_uuid}, context={"request": request})
-        req.is_valid(raise_exception=True)
+    def get_queryset(self, group_uuid: UUID) -> Tuple[StudyGroup, "QuerySet[StudyReview]"]:
+        # 스터디 그룹 검증 (없으면 404)
+        group = get_object_or_404(StudyGroup, uuid=group_uuid)
 
-        group: StudyGroup = req.context["study_group"]
-
+        # 리뷰 목록 조회 (없으면 빈 리스트 반환)
         qs = StudyReview.objects.filter(study_group=group).order_by("-created_at")
+        return group, qs
+
+    def get(self, request: Request, group_uuid: UUID, *args: object, **kwargs: object) -> Response:
+        group, qs = self.get_queryset(group_uuid)
         payload = {"study_group_id": group.id, "reviews": qs}
 
         res = ReviewListResponseSerializer(payload, context={"request": request})

--- a/apps/studies/views/review_views.py
+++ b/apps/studies/views/review_views.py
@@ -1,66 +1,70 @@
-from typing import Tuple
+from typing import cast
 from uuid import UUID
 
 from django.db.models import QuerySet
-from django.shortcuts import get_object_or_404
 from rest_framework import status
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.studies.models.study_groups import StudyGroup
-from apps.studies.models.study_reviews import StudyReview
+from apps.studies.models import StudyGroup, StudyReview
 from apps.studies.serializers.review_serializers import (
     ReviewCreateRequestSerializer,
     ReviewCreateResponseSerializer,
     ReviewListResponseSerializer,
 )
+from apps.users.models import User
 
 
-class ReviewCreateAPIView(APIView):
+class ReviewCreateListAPIView(APIView):
     """
     [REQ-REVW-001] 스터디 그룹 리뷰 작성 API
-    POST /api/v1/reviews/
-    """
-
-    def post(self, request: Request, *args: object, **kwargs: object) -> Response:
-        # 요청 검증
-        request_serializer = ReviewCreateRequestSerializer(data=request.data, context={"request": request})
-        if request_serializer.is_valid():
-            # 저장
-            review = request_serializer.save()
-
-            # 응답 변환
-            response_serializer = ReviewCreateResponseSerializer(review)
-            return Response(response_serializer.data, status=status.HTTP_201_CREATED)
-
-        return Response(request_serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-
-class StudyGroupReviewListView(APIView):
-    """
+    POST /api/v1/reviews
     [REQ-REVW-00] 스터디 그룹 리뷰 목록 조회 API
-    GET /api/v1/study-groups/reviews/{group_uuid}/
+    GET /api/v1/study-groups/reviews/{group_uuid}
     """
 
-    permission_classes = [IsAuthenticated]
+    permission_classes = [IsAuthenticatedOrReadOnly]
+
+    def post(self, request: Request, group_uuid: UUID) -> Response:
+        user = cast(User, request.user)
+        try:
+            study_group = StudyGroup.objects.get(uuid=group_uuid)
+        except StudyGroup.DoesNotExist:
+            return Response(
+                {"error": f"study group not found - uuid: {group_uuid}"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if study_group.status != StudyGroup.StatusChoices.ENDED:
+            return Response(
+                {"error": "종료되지 않은 스터디 그룹에는 리뷰를 작성할 수 없습니다."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        if StudyReview.objects.filter(user=user, study_group=study_group).exists():
+            return Response({"error": "이미 작성된 리뷰가 있습니다."}, status=status.HTTP_400_BAD_REQUEST)
+
+        request_serializer = ReviewCreateRequestSerializer(data=request.data)
+        # 요청 데이터 검증
+        request_serializer.is_valid(raise_exception=True)
+        # 저장
+        review = request_serializer.save(study_group=study_group, user=user)
+        # 응답 변환
+        response_serializer = ReviewCreateResponseSerializer(review)
+        return Response(response_serializer.data, status=status.HTTP_201_CREATED)
 
     def get_queryset(self, group_uuid: UUID) -> QuerySet[StudyReview]:
-        return StudyReview.objects.filter(study_group__uuid=group_uuid).order_by("-created_at")
+        # 스터디 그룹 UUID를 통해 리뷰 목록 최신순 조회
+        return (
+            StudyReview.objects.select_related("study_group")
+            .filter(study_group__uuid=group_uuid)
+            .order_by("-created_at")
+        )
 
     def get(self, request: Request, group_uuid: UUID, *args: object, **kwargs: object) -> Response:
+        if not StudyGroup.objects.filter(uuid=group_uuid).exists():
+            return Response({"error": "study_group_uuid invalid."}, status=status.HTTP_400_BAD_REQUEST)
         qs = self.get_queryset(group_uuid)
-
-        study_group_id = qs.values_list("study_group_id", flat=True).first()
-
-        # 리뷰가 없으면 → StudyGroup 존재 여부 확인 후 id 가져오기
-        if study_group_id is None:
-            study_group_id = get_object_or_404(StudyGroup, uuid=group_uuid).id
-
-        payload = {
-            "study_group_id": study_group_id,
-            "reviews": qs,
-        }
-        res = ReviewListResponseSerializer(payload, context={"request": request})
-        return Response(res.data)
+        res = ReviewListResponseSerializer(qs, many=True)
+        return Response(res.data, status=status.HTTP_200_OK)

--- a/apps/studies/views/views.py
+++ b/apps/studies/views/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.


### PR DESCRIPTION
##  PR 요약
- 관련 이슈 번호: #110 
- 작업 요약:  스터디 그룹 리뷰 목록 조회 API를 구현했습니다.

## 📄 상세 내용
- ReviewListRequestSerializer: `group_uuid` 유효성 검증 및 queryset 반환
- ReviewListItemSerializer / ReviewListResponseSerializer 추가
  - rating, content, created_at 필드만 노출
- 최신순 정렬 기능 적용
- 리뷰가 없는 경우 404 응답 처리
- 테스트 코드 작성 및 테스트 커버리지 100% 달성
## 📸 스크린샷 (선택)
<img width="835" height="545" alt="image" src="https://github.com/user-attachments/assets/95483737-99cc-475f-8d03-fcc02258ac8d" />

## 📝 기타 참고 사항
- API 명세서와 응답 형식 일치
- 사용자 요구 정의서 반영
- 커밋메세지를 잘못 남겨 변경하려고 했으나 vim에서 style 이모지가 입력되지 않아 이모지를 넣지 못했습니다.
## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 모두 통과했습니다. (커버리지 100%)
