### PR TITLE
✨ feat:소셜 로그인 카카오 기능 개발

### DIFF
--- a/apps/users/serializers/social_user.py
+++ b/apps/users/serializers/social_user.py
@@ -1,0 +1,34 @@
+from rest_framework import serializers
+
+from apps.users.models import SocialUser, User
+
+
+class UserResponseSerializer(serializers.ModelSerializer[User]):
+    provider = serializers.SerializerMethodField()
+
+    class Meta:
+        model = User
+        fields = [
+            "id",
+            "email",
+            "nickname",
+            "phone_number",
+            "name",
+            "birthday",
+            "gender",
+            "profile_img_url",
+            "provider",
+        ]
+
+    def get_provider(self, obj: User) -> str | None:
+        social_user = SocialUser.objects.filter(user=obj).first()
+        return social_user.provider if social_user else None
+
+
+class KakaoLoginResponseSerializer(serializers.Serializer[dict[str, object]]):
+    # API 응답 스펙을 명시적으로 정의하는 클래스
+    message = serializers.CharField()  # 서버가 내려주는 설명메시지 ex) 로그인 되었습니다./ 로그인 실패했습니다.
+    access = serializers.CharField()  # JWT 토큰
+    refresh = serializers.CharField()  # JWT 토큰
+    is_new_user = serializers.BooleanField()  # 신규유저 여부
+    user = UserResponseSerializer()

--- a/apps/users/services/social_user.py
+++ b/apps/users/services/social_user.py
@@ -1,0 +1,155 @@
+from typing import Any
+
+import requests
+from django.conf import settings
+from django.core.cache import cache
+from rest_framework.exceptions import APIException
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from apps.users.models import SocialUser, User
+from apps.users.serializers.social_user import UserResponseSerializer
+
+
+class KakaoService:  # 카카오 로그인 로직 담당 클래스
+    TOKEN_URL = "https://kauth.kakao.com/oauth/token"  # 카카오 토큰 발급 API URL
+    USER_INFO_URL = "https://kapi.kakao.com/v2/user/me"  # 카카오 사용자 정보 API URL
+
+    def __init__(self) -> None:
+        self.client_id = settings.KAKAO_CLIENT_ID  # 카카오 개발자 페이지 REST API
+        self.redirect_uri = settings.KAKAO_REDIRECT_URI  # 카카오 개발자 페이지 redirect uri에 등록
+
+    def get_access_token(self, code: str) -> dict[str, Any]:  # 인가 코드로 access_token 요청
+        data = {
+            "grant_type": "authorization_code",
+            "client_id": self.client_id,
+            "redirect_uri": self.redirect_uri,
+            "code": code,
+        }
+        try:
+            res = requests.post(self.TOKEN_URL, data=data, timeout=5)
+            res.raise_for_status()
+            body: dict[str, Any] = res.json()
+            access_token = body.get("access_token")
+            refresh_token = body.get("refresh_token")
+            access_token_expires_in = body.get("expires_in")
+            refresh_token_expires_in = body.get("refresh_token_expires_in")
+            if not access_token:
+                raise APIException("카카오 access_token 발급 실패")
+            return {
+                "access_token": access_token,
+                "refresh_token": refresh_token,
+                "access_token_expires_in": access_token_expires_in,
+                "refresh_token_expires_in": refresh_token_expires_in,
+            }
+        except requests.exceptions.RequestException as e:
+            raise APIException(f"Kakao API 호출 실패: {str(e)}")
+
+    def get_user_info(self, access_token: str) -> dict[str, Any]:  # access_token으로 사용자 정보 조회
+        try:
+            headers = {"Authorization": f"Bearer {access_token}"}
+            res = requests.get(self.USER_INFO_URL, headers=headers, timeout=5)
+            res.raise_for_status()
+            body: dict[str, Any] = res.json()
+            if not body.get("id"):
+                raise APIException("카카오 사용자 정보 조회 실패")
+            return body
+        except requests.exceptions.RequestException as e:
+            raise APIException(f"Kakao API 호출 실패: {str(e)}")
+
+    def unique_nickname(self, base_nickname: str) -> str:
+        # 닉네임 중복 방지
+        nickname = base_nickname
+        counter = 1
+        while User.objects.filter(nickname=nickname).exists():
+            nickname = f"{base_nickname}{counter}"
+            counter += 1
+        return nickname
+
+    def login_or_signup(self, kakao_user: dict[str, Any]) -> tuple[User, bool]:  # 기존 유저면 로그인, 신규면 회원가입
+        kakao_id = str(kakao_user.get("id"))
+        kakao_account = kakao_user.get("kakao_account", {})
+
+        email = kakao_account.get("email")
+        nickname = self.unique_nickname(kakao_account.get("profile", {}).get("nickname", "kakao_user"))
+        name = kakao_account.get("name")
+        phone_number = kakao_account.get("phone_number")
+        birthday = kakao_account.get("birthday")
+        gender = kakao_account.get("gender")
+        profile_image = kakao_account.get("profile", {}).get("profile_image_url")
+
+        try:
+            social_user = SocialUser.objects.get(
+                provider=SocialUser.ProviderChoices.KAKAO,
+                provider_id=kakao_id,
+            )
+            return social_user.user, False
+        except SocialUser.DoesNotExist:
+            # 유저를 먼저 생성
+            user = User(
+                email=email,
+                nickname=nickname,
+                phone_number=phone_number,
+                name=name,
+                birthday=birthday,
+                gender=gender,
+                profile_img_url=profile_image,
+                is_active=True,
+            )
+            user.set_unusable_password()
+            user.save()
+            # 이후에 소셜유저 생성
+            SocialUser.objects.create(
+                user=user,
+                provider=SocialUser.ProviderChoices.KAKAO,
+                provider_id=kakao_id,
+            )
+            return user, True
+
+    def generate_tokens(self, user: User) -> dict[str, str]:  # JWT 토큰 발급
+        refresh = RefreshToken.for_user(user)
+        return {
+            "access": str(refresh.access_token),
+            "refresh": str(refresh),
+        }
+
+    def kakao_login(self, code: str) -> dict[str, Any]:
+        # 카카오 로그인 절차
+        tokens_from_kakao = self.get_access_token(code)
+        kakao_access_token = tokens_from_kakao["access_token"]
+        kakao_refresh_token = tokens_from_kakao.get("refresh_token")
+
+        # 사용자 정보 조회
+        kakao_user = self.get_user_info(kakao_access_token)
+
+        # 로그인 or 회원가입
+        user, created = self.login_or_signup(kakao_user)
+
+        # JWT 토큰 발급
+        jwt_tokens = self.generate_tokens(user)
+
+        access_token_expires_in = tokens_from_kakao.get(
+            "access_token_expires_in", 21599
+        )  # 카카오에서 제공하는 access_token 기한 6시간
+        refresh_token_expires_in = tokens_from_kakao.get(
+            "refresh_token_expires_in", 5184000
+        )  # 카카오에서 제공하는 refresh_token 기한 60일
+        # Redis 캐시에 카카오 토큰 저장 (회원탈퇴 때 사용)
+        cache.set(
+            f"kakao_access_token:{user.id}",
+            kakao_access_token,
+            timeout=int(access_token_expires_in),
+        )
+        if kakao_refresh_token:
+            cache.set(
+                f"kakao_refresh_token:{user.id}",
+                kakao_refresh_token,
+                timeout=int(refresh_token_expires_in),
+            )
+
+        return {
+            "message": "Kakao login successful",
+            "access": jwt_tokens["access"],
+            "refresh": jwt_tokens["refresh"],
+            "is_new_user": created,
+            "user": UserResponseSerializer(user).data,
+        }

--- a/apps/users/tests/test_social_user.py
+++ b/apps/users/tests/test_social_user.py
@@ -1,0 +1,137 @@
+from typing import Any
+from unittest.mock import Mock, patch
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.users.models import SocialUser, User
+
+
+class TestKakaoLogin(APITestCase):
+    url: str
+    token_response: dict[str, Any]
+    user_response: dict[str, Any]
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.url = reverse("kakao_callback")
+
+        cls.token_response = {
+            "access_token": "fake_access_token",
+            "refresh_token": "fake_refresh_token",
+            "expires_in": 21599,
+            "refresh_token_expires_in": 5184000,
+        }
+
+        cls.user_response = {
+            "id": "12345",
+            "kakao_account": {
+                "email": "test@example.com",
+                "profile": {
+                    "nickname": "testuser",
+                    "profile_image_url": "http://example.com/image.png",
+                },
+                "name": "김오즈",
+                "phone_number": "010-1234-5678",
+                "birthday": "2000-01-01",
+                "gender": "male",
+            },
+        }
+
+    def test_missing_code_returns_400(self) -> None:
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["message"], "code is required")
+
+    @patch("apps.users.services.social_user.cache.set")
+    def test_successful_login_flow(self, mock_cache_set: Mock) -> None:
+        with patch("apps.users.services.social_user.requests.post") as mock_post, patch(
+            "apps.users.services.social_user.requests.get"
+        ) as mock_get:
+            mock_post.return_value.json.return_value = self.token_response
+            mock_post.return_value.raise_for_status = lambda: None
+            mock_get.return_value.json.return_value = self.user_response
+            mock_get.return_value.raise_for_status = lambda: None
+
+            response = self.client.get(self.url, {"code": "dummy_code"})
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertEqual(response.data["message"], "Kakao login successful")
+            self.assertEqual(response.data["user"]["email"], "test@example.com")
+
+            user = User.objects.get(email="test@example.com")
+            social_user = SocialUser.objects.get(user=user)
+            self.assertEqual(social_user.provider, SocialUser.ProviderChoices.KAKAO)
+            self.assertEqual(social_user.provider_id, "12345")
+
+    @patch("apps.users.services.social_user.requests.post")
+    def test_invalid_code_or_api_failure(self, mock_post: Mock) -> None:
+        mock_post.side_effect = Exception("카카오 API 호출 실패")
+
+        response = self.client.get(self.url, {"code": "wrong_code"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("잘못된 요청", response.data["message"])
+
+    @patch("apps.users.services.social_user.cache.set")
+    def test_existing_user_login(self, mock_cache_set: Mock) -> None:
+        user = User.objects.create(
+            email="test@example.com",
+            nickname="testuser",
+            is_active=True,
+            birthday="2000-01-01",
+        )
+        SocialUser.objects.create(
+            user=user,
+            provider=SocialUser.ProviderChoices.KAKAO,
+            provider_id="12345",
+        )
+
+        with patch("apps.users.services.social_user.requests.post") as mock_post, patch(
+            "apps.users.services.social_user.requests.get"
+        ) as mock_get:
+            mock_post.return_value.json.return_value = self.token_response
+            mock_post.return_value.raise_for_status = lambda: None
+            mock_get.return_value.json.return_value = self.user_response
+            mock_get.return_value.raise_for_status = lambda: None
+
+            response = self.client.get(self.url, {"code": "dummy_code"})
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            self.assertFalse(response.data["is_new_user"])  # 신규 아님
+            self.assertEqual(User.objects.filter(email="test@example.com").count(), 1)
+
+    @patch("apps.users.services.social_user.cache.set")
+    def test_cache_set_called(self, mock_cache_set: Mock) -> None:
+        """Redis 캐시 저장 로직이 호출되는지 검증"""
+        with patch("apps.users.services.social_user.requests.post") as mock_post, patch(
+            "apps.users.services.social_user.requests.get"
+        ) as mock_get:
+            mock_post.return_value.json.return_value = self.token_response
+            mock_post.return_value.raise_for_status = lambda: None
+            mock_get.return_value.json.return_value = self.user_response
+            mock_get.return_value.raise_for_status = lambda: None
+
+            self.client.get(self.url, {"code": "dummy_code"})
+
+            mock_cache_set.assert_any_call(
+                "kakao_access_token:1",  # user.id는 1번째라 가정
+                "fake_access_token",
+                timeout=21599,
+            )
+
+    @patch("apps.users.services.social_user.requests.get")
+    def test_user_info_missing_id(self, mock_get: Mock) -> None:
+        """카카오 응답에 id 누락 → 실패 처리"""
+        mock_get.return_value.json.return_value = {
+            "kakao_account": {"email": "test@example.com"}
+        }
+        mock_get.return_value.raise_for_status = lambda: None
+
+        with patch("apps.users.services.social_user.requests.post") as mock_post:
+            mock_post.return_value.json.return_value = self.token_response
+            mock_post.return_value.raise_for_status = lambda: None
+
+            response = self.client.get(self.url, {"code": "dummy_code"})
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+            self.assertIn("잘못된 요청", response.data["message"])

--- a/apps/users/urls/auth_urls.py
+++ b/apps/users/urls/auth_urls.py
@@ -9,6 +9,7 @@ from apps.users.views.email_view import (
     SignUpEmailVerifiCationVerifyAPIView,
 )
 from apps.users.views.phone_view import SendVerificationCodeAPIView, VerifyCodeAPIView
+from apps.users.views.social_user import KakaoLoginCallbackView
 from apps.users.views.withdrawals import WithdrawalAPIView
 
 urlpatterns = [
@@ -31,4 +32,5 @@ urlpatterns = [
     path("auth/phone/send-code", SendVerificationCodeAPIView.as_view(), name="phone_send_code"),
     path("auth/phone/verify-code", VerifyCodeAPIView.as_view(), name="phone_verify_code"),
     path("auth/withdraw", WithdrawalAPIView.as_view(), name="account_withdrawals"),
+    path("auth/kakao/callback", KakaoLoginCallbackView.as_view(), name="kakao_callback"),
 ]

--- a/apps/users/views/social_user.py
+++ b/apps/users/views/social_user.py
@@ -1,0 +1,32 @@
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.users.serializers.social_user import KakaoLoginResponseSerializer
+from apps.users.services.social_user import KakaoService
+
+
+class KakaoLoginCallbackView(APIView):
+    def get(self, request: Request) -> Response:
+        code: str | None = request.query_params.get("code")
+        if not code:
+            return Response(
+                {"message": "code is required"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        service = KakaoService()
+
+        try:
+            result = service.kakao_login(code)
+
+            serializer = KakaoLoginResponseSerializer(result)
+
+            return Response(serializer.data, status=status.HTTP_200_OK)
+
+        except Exception as e:
+            return Response(
+                {"message": f"잘못된 요청: {str(e)}"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -1,3 +1,5 @@
+import os
+
 from config.settings.base import *
 
 DEBUG = True
@@ -19,3 +21,6 @@ CORS_ALLOWED_ORIGINS = [
     "http://localhost:3000",
     "http://127.0.0.1:3000",
 ]
+
+KAKAO_CLIENT_ID = os.getenv("KAKAO_CLIENT_ID")
+KAKAO_REDIRECT_URI = os.getenv("KAKAO_REDIRECT_URI")


### PR DESCRIPTION
apps.users.serializers.social_user 작성
apps.users.services.social_user 작성
apps.users.views.social_user 작성
apps.users.test.test_social_user 작성
apps.users.urls.auth_urls에 KakaoLoginCallbackView 연결 config.settings.local에 restAPI, redirect uri 등록

관련 이슈 #114

 ✅ PR 요약
- 관련 이슈 번호: #114 
- 작업 요약: 소셜 로그인 카카오 기능 개발 했습니다.

 📄 상세 내용
- [x] 카카오 소셜 로그인 기능 구현
카카오 OAuth2 인증 절차 처리하는 KakaoService작성

- [x] serializers 작성
User 모델의 응답 스펙 정의 UserResponseSerializer
카카오 로그인 성공 시 응답 스펙 정의 KakaoLoginResponseSerializer

- [x] test code 작성 
code 누락 시 400 응답
정상 로그인 시 신규 유저 생성
잘못된 code 또는 API 실패 시 400 응답
기존 유저일 경우 is_new_user False 인지 확인
redis 캐시 저장 로직이 호출 되는지 확인
카카오 id  누락 시 400응답


## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
