### PR TITLE
스터디 참여 시 기존 그룹원에게 알림 발생

### DIFF
--- a/apps/notifications/receivers.py
+++ b/apps/notifications/receivers.py
@@ -29,7 +29,7 @@ def notify_add_application(instance: Application, created: bool, **kwargs: Any) 
     app_id = instance.pk
 
     def add_application() -> None:
-        ApplicationNotificationService.from_id(app_id).notification_add_application()
+        ApplicationNotificationService.from_id(app_id).notify_add_application()
 
     transaction.on_commit(add_application)
 
@@ -49,10 +49,10 @@ def notify_status_change_to_applicant(instance: Application, created: bool, **kw
     if curr == Application.ApplicationStatus.ACCEPTED:  # 현재가 승인  상태로 바뀐 경우만
 
         def accept_application() -> None:
-            ApplicationNotificationService.from_id(app_id).notification_application_accept()
+            ApplicationNotificationService.from_id(app_id).notify_application_accept()
 
         def join_study_group() -> None:
-            ApplicationNotificationService.from_id(app_id).notification_group_members_join()
+            ApplicationNotificationService.from_id(app_id).notify_group_members_join()
 
         transaction.on_commit(accept_application)
         transaction.on_commit(join_study_group)
@@ -60,6 +60,6 @@ def notify_status_change_to_applicant(instance: Application, created: bool, **kw
     if curr == Application.ApplicationStatus.REJECTED:
 
         def reject_application() -> None:
-            ApplicationNotificationService.from_id(app_id).notification_application_reject()
+            ApplicationNotificationService.from_id(app_id).notify_application_reject()
 
         transaction.on_commit(reject_application)

--- a/apps/notifications/receivers.py
+++ b/apps/notifications/receivers.py
@@ -51,7 +51,11 @@ def notify_status_change_to_applicant(instance: Application, created: bool, **kw
         def accept_application() -> None:
             NotificationCreateApplicationService.notification_application_accept_by_id(app_id)
 
+        def join_study_group() -> None:
+            NotificationCreateApplicationService.notification_group_members_join_by_id(app_id)
+
         transaction.on_commit(accept_application)
+        transaction.on_commit(join_study_group)
 
     if curr == Application.ApplicationStatus.REJECTED:
 

--- a/apps/notifications/receivers.py
+++ b/apps/notifications/receivers.py
@@ -6,7 +6,7 @@ from django.dispatch import receiver
 
 from apps.applications.models import Application
 from apps.notifications.services.noti_create_service import (
-    NotificationCreateService,
+    ApplicationNotificationService,
 )
 
 
@@ -29,7 +29,7 @@ def notify_add_application(instance: Application, created: bool, **kwargs: Any) 
     app_id = instance.pk
 
     def add_application() -> None:
-        NotificationCreateService.from_id(app_id).notification_add_application()
+        ApplicationNotificationService.from_id(app_id).notification_add_application()
 
     transaction.on_commit(add_application)
 
@@ -49,10 +49,10 @@ def notify_status_change_to_applicant(instance: Application, created: bool, **kw
     if curr == Application.ApplicationStatus.ACCEPTED:  # 현재가 승인  상태로 바뀐 경우만
 
         def accept_application() -> None:
-            NotificationCreateService.from_id(app_id).notification_application_accept()
+            ApplicationNotificationService.from_id(app_id).notification_application_accept()
 
         def join_study_group() -> None:
-            NotificationCreateService.from_id(app_id).notification_group_members_join()
+            ApplicationNotificationService.from_id(app_id).notification_group_members_join()
 
         transaction.on_commit(accept_application)
         transaction.on_commit(join_study_group)
@@ -60,6 +60,6 @@ def notify_status_change_to_applicant(instance: Application, created: bool, **kw
     if curr == Application.ApplicationStatus.REJECTED:
 
         def reject_application() -> None:
-            NotificationCreateService.from_id(app_id).notification_application_reject()
+            ApplicationNotificationService.from_id(app_id).notification_application_reject()
 
         transaction.on_commit(reject_application)

--- a/apps/notifications/receivers.py
+++ b/apps/notifications/receivers.py
@@ -6,7 +6,7 @@ from django.dispatch import receiver
 
 from apps.applications.models import Application
 from apps.notifications.services.noti_create_service import (
-    NotificationCreateApplicationService,
+    NotificationCreateService,
 )
 
 
@@ -29,7 +29,7 @@ def notify_add_application(instance: Application, created: bool, **kwargs: Any) 
     app_id = instance.pk
 
     def add_application() -> None:
-        NotificationCreateApplicationService.notification_add_application_by_id(app_id)
+        NotificationCreateService.from_id(app_id).notification_add_application()
 
     transaction.on_commit(add_application)
 
@@ -49,10 +49,10 @@ def notify_status_change_to_applicant(instance: Application, created: bool, **kw
     if curr == Application.ApplicationStatus.ACCEPTED:  # 현재가 승인  상태로 바뀐 경우만
 
         def accept_application() -> None:
-            NotificationCreateApplicationService.notification_application_accept_by_id(app_id)
+            NotificationCreateService.from_id(app_id).notification_application_accept()
 
         def join_study_group() -> None:
-            NotificationCreateApplicationService.notification_group_members_join_by_id(app_id)
+            NotificationCreateService.from_id(app_id).notification_group_members_join()
 
         transaction.on_commit(accept_application)
         transaction.on_commit(join_study_group)
@@ -60,6 +60,6 @@ def notify_status_change_to_applicant(instance: Application, created: bool, **kw
     if curr == Application.ApplicationStatus.REJECTED:
 
         def reject_application() -> None:
-            NotificationCreateApplicationService.notification_application_reject_by_id(app_id)
+            NotificationCreateService.from_id(app_id).notification_application_reject()
 
         transaction.on_commit(reject_application)

--- a/apps/notifications/services/noti_create_service.py
+++ b/apps/notifications/services/noti_create_service.py
@@ -20,7 +20,7 @@ class ApplicationNotificationService:
         )
         return cls(app)
 
-    def notification_add_application(self) -> Notification:
+    def notify_add_application(self) -> Notification:
         rec = self.app.recruitment
         if rec is None:  # mypy
             raise ValueError("Application.recruitment is None")
@@ -32,7 +32,7 @@ class ApplicationNotificationService:
             back_url_link=f"/recruitments/{rec.uuid}/applications",
         )
 
-    def notification_application_accept(self) -> Notification:
+    def notify_application_accept(self) -> Notification:
         if self.app.status != Application.ApplicationStatus.ACCEPTED:
             raise ValueError("Application status is not accepted")
 
@@ -47,7 +47,7 @@ class ApplicationNotificationService:
             back_url_link=f"/my-page/applications",
         )
 
-    def notification_application_reject(self) -> Notification:
+    def notify_application_reject(self) -> Notification:
         if self.app.status != Application.ApplicationStatus.REJECTED:
             raise ValueError("Application.status is not REJECTED")
 
@@ -62,7 +62,7 @@ class ApplicationNotificationService:
             back_url_link="/my-page/applications",
         )
 
-    def notification_group_members_join(self) -> int:
+    def notify_group_members_join(self) -> int:
         if self.app.status != Application.ApplicationStatus.ACCEPTED:
             return 0
         rec = self.app.recruitment

--- a/apps/notifications/services/noti_create_service.py
+++ b/apps/notifications/services/noti_create_service.py
@@ -5,16 +5,16 @@ from apps.notifications.models import Notification
 from apps.studies.models import GroupMember
 
 
-class NotificationCreateService:
+class ApplicationNotificationService:
     def __init__(self, app: Application):
         self.app = app
 
     @classmethod
-    def from_instance(cls, app: Application) -> "NotificationCreateService":
+    def from_instance(cls, app: Application) -> "ApplicationNotificationService":
         return cls(app)
 
     @classmethod
-    def from_id(cls, app_id: int) -> "NotificationCreateService":
+    def from_id(cls, app_id: int) -> "ApplicationNotificationService":
         app = Application.objects.select_related("recruitment__author", "recruitment__study_group", "user").get(
             pk=app_id
         )
@@ -69,8 +69,7 @@ class NotificationCreateService:
         if rec is None:  # mypy
             return 0
         group = rec.study_group
-        if group is None:  # mypy
-            return 0
+
         new_user = self.app.user
 
         # 그룹에 참여중인 멤버들

--- a/apps/notifications/services/noti_create_service.py
+++ b/apps/notifications/services/noti_create_service.py
@@ -1,5 +1,8 @@
+from django.db import transaction
+
 from apps.applications.models.applications import Application
 from apps.notifications.models import Notification
+from apps.studies.models import StudyGroup
 
 
 class NotificationCreateApplicationService:
@@ -41,7 +44,7 @@ class NotificationCreateApplicationService:
             user_id=app.user_id,
             content=f"{rec.title} 구인 공고에 대한 지원 내역이 승인 되었습니다.",
             notification_type=Notification.NotificationType.APPLICATION_ACCEPT,
-            back_url_link=f"/applications/me",
+            back_url_link=f"/my-page/applications",
         )
 
     # 지원자에게 거절 알림
@@ -63,5 +66,49 @@ class NotificationCreateApplicationService:
             user_id=app.user_id,  # 수신자 = 지원자
             content=f"{rec.title} 구인 공고에 대한 지원 내역이 거절되었습니다.",
             notification_type=Notification.NotificationType.APPLICATION_REJECT,
-            back_url_link="/applications/me",
+            back_url_link="/my-page/applications",
         )
+
+    @classmethod
+    def notification_group_members_join_by_id(cls, app_id: int) -> int:
+        app = Application.objects.select_related("recruitment__author", "recruitment__study_group", "user").get(
+            pk=app_id
+        )
+        return cls.notification_group_members_join(app)
+
+    @classmethod
+    def notification_group_members_join(cls, app: Application) -> int:
+        if app.status != Application.ApplicationStatus.ACCEPTED:
+            return 0
+        rec = app.recruitment
+        if rec is None:  # mypy
+            return 0
+        group = rec.study_group
+        if group is None:  # mypy
+            return 0
+        new_user = app.user
+
+        # 그룹에 참여중인 멤버들
+        accepted_user_ids = set(
+            Application.objects.filter(
+                recruitment__study_group=group.id, status=Application.ApplicationStatus.ACCEPTED
+            ).values_list("user_id", flat=True)
+        )
+
+        if new_user.id in accepted_user_ids:
+            accepted_user_ids.remove(new_user.id)
+
+        notifications = [
+            Notification(
+                user_id=uid,
+                content=f"{group.name}에 {new_user.nickname} 님이 참여했습니다. 환영해주세요!",
+                notification_type=Notification.NotificationType.STUDY_JOIN,
+                back_url_link=f"{group.id}",
+            )
+            for uid in accepted_user_ids
+        ]
+
+        with transaction.atomic():
+            created = Notification.objects.bulk_create(notifications)
+
+        return len(created)

--- a/apps/notifications/services/noti_create_service.py
+++ b/apps/notifications/services/noti_create_service.py
@@ -2,7 +2,7 @@ from django.db import transaction
 
 from apps.applications.models.applications import Application
 from apps.notifications.models import Notification
-from apps.studies.models import StudyGroup
+from apps.studies.models import GroupMember
 
 
 class NotificationCreateApplicationService:
@@ -89,21 +89,18 @@ class NotificationCreateApplicationService:
         new_user = app.user
 
         # 그룹에 참여중인 멤버들
-        accepted_user_ids = set(
-            Application.objects.filter(
-                recruitment__study_group=group.id, status=Application.ApplicationStatus.ACCEPTED
-            ).values_list("user_id", flat=True)
-        )
+        accepted_user_ids = set(GroupMember.objects.filter(study_group=group.id).values_list("user_id", flat=True))
 
-        if new_user.id in accepted_user_ids:
-            accepted_user_ids.remove(new_user.id)
+        accepted_user_ids.discard(new_user.id)
+        if not accepted_user_ids:
+            return 0
 
         notifications = [
             Notification(
                 user_id=uid,
                 content=f"{group.name}에 {new_user.nickname} 님이 참여했습니다. 환영해주세요!",
                 notification_type=Notification.NotificationType.STUDY_JOIN,
-                back_url_link=f"{group.id}",
+                back_url_link=f"/study-groups/{group.id}/chat",
             )
             for uid in accepted_user_ids
         ]

--- a/apps/notifications/services/noti_create_service.py
+++ b/apps/notifications/services/noti_create_service.py
@@ -5,16 +5,23 @@ from apps.notifications.models import Notification
 from apps.studies.models import GroupMember
 
 
-class NotificationCreateApplicationService:
-    # 공고 지원 시 알림
-    @classmethod
-    def notification_add_application_by_id(cls, app_id: int) -> Notification:  # N+1 방지를 위함
-        app = Application.objects.select_related("recruitment__author", "recruitment", "user").get(pk=app_id)
-        return cls.notification_add_application(app)
+class NotificationCreateService:
+    def __init__(self, app: Application):
+        self.app = app
 
     @classmethod
-    def notification_add_application(cls, app: Application) -> Notification:
-        rec = app.recruitment
+    def from_instance(cls, app: Application) -> "NotificationCreateService":
+        return cls(app)
+
+    @classmethod
+    def from_id(cls, app_id: int) -> "NotificationCreateService":
+        app = Application.objects.select_related("recruitment__author", "recruitment__study_group", "user").get(
+            pk=app_id
+        )
+        return cls(app)
+
+    def notification_add_application(self) -> Notification:
+        rec = self.app.recruitment
         if rec is None:  # mypy
             raise ValueError("Application.recruitment is None")
 
@@ -25,68 +32,46 @@ class NotificationCreateApplicationService:
             back_url_link=f"/recruitments/{rec.uuid}/applications",
         )
 
-    # 지원자에게 승인 알림
-    @classmethod
-    def notification_application_accept_by_id(cls, app_id: int) -> Notification:  # N+1 방지를 위함
-        app = Application.objects.select_related("recruitment__author", "recruitment", "user").get(pk=app_id)
-        return cls.notification_application_accept(app)
-
-    @classmethod
-    def notification_application_accept(cls, app: Application) -> Notification:
-        if app.status != Application.ApplicationStatus.ACCEPTED:
+    def notification_application_accept(self) -> Notification:
+        if self.app.status != Application.ApplicationStatus.ACCEPTED:
             raise ValueError("Application status is not accepted")
 
-        rec = app.recruitment
+        rec = self.app.recruitment
         if rec is None:
             raise ValueError("Recruitment is None")
 
         return Notification.objects.create(
-            user_id=app.user_id,
+            user_id=self.app.user_id,
             content=f"{rec.title} 구인 공고에 대한 지원 내역이 승인 되었습니다.",
             notification_type=Notification.NotificationType.APPLICATION_ACCEPT,
             back_url_link=f"/my-page/applications",
         )
 
-    # 지원자에게 거절 알림
-    @classmethod
-    def notification_application_reject_by_id(cls, app_id: int) -> Notification:
-        app = Application.objects.select_related("recruitment__author", "recruitment", "user").get(pk=app_id)
-        return cls.notification_application_reject(app)
-
-    @classmethod
-    def notification_application_reject(cls, app: Application) -> Notification:
-        if app.status != Application.ApplicationStatus.REJECTED:
+    def notification_application_reject(self) -> Notification:
+        if self.app.status != Application.ApplicationStatus.REJECTED:
             raise ValueError("Application.status is not REJECTED")
 
-        rec = app.recruitment
+        rec = self.app.recruitment
         if rec is None:
             raise ValueError("Application.recruitment is None")
 
         return Notification.objects.create(
-            user_id=app.user_id,  # 수신자 = 지원자
+            user_id=self.app.user_id,  # 수신자 = 지원자
             content=f"{rec.title} 구인 공고에 대한 지원 내역이 거절되었습니다.",
             notification_type=Notification.NotificationType.APPLICATION_REJECT,
             back_url_link="/my-page/applications",
         )
 
-    @classmethod
-    def notification_group_members_join_by_id(cls, app_id: int) -> int:
-        app = Application.objects.select_related("recruitment__author", "recruitment__study_group", "user").get(
-            pk=app_id
-        )
-        return cls.notification_group_members_join(app)
-
-    @classmethod
-    def notification_group_members_join(cls, app: Application) -> int:
-        if app.status != Application.ApplicationStatus.ACCEPTED:
+    def notification_group_members_join(self) -> int:
+        if self.app.status != Application.ApplicationStatus.ACCEPTED:
             return 0
-        rec = app.recruitment
+        rec = self.app.recruitment
         if rec is None:  # mypy
             return 0
         group = rec.study_group
         if group is None:  # mypy
             return 0
-        new_user = app.user
+        new_user = self.app.user
 
         # 그룹에 참여중인 멤버들
         accepted_user_ids = set(GroupMember.objects.filter(study_group=group.id).values_list("user_id", flat=True))

--- a/apps/notifications/tests/test_notification_create.py
+++ b/apps/notifications/tests/test_notification_create.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from apps.applications.models.applications import Application
 from apps.notifications.models import Notification
 from apps.recruitments.models.recruitments import Recruitment
+from apps.studies.models import GroupMember
 from apps.studies.models.study_groups import StudyGroup
 from apps.users.models.user import User
 
@@ -161,3 +162,74 @@ class NotificationOnApplicationCreateTests(TransactionTestCase):
             app.status = Application.ApplicationStatus.REJECTED
             app.save(update_fields=["status"])
         self.assertEqual(notifs.count(), 1)
+
+    def test_notification_created_after_accept_status_change_by_study_join(self) -> None:
+        """
+        Application 상태가 PENDING -> ACCEPTED로 바뀌면
+        on_commit 이후 기존 스터디 그룹원에게 신규 인원이 있다는 알림 발생
+        """
+        # 기존 멤버
+        old_member = User.objects.create_user(
+            email="oldmember@example.com",
+            password="pass1234!",
+            nickname="oz",
+            name="Old Member",
+            phone_number="01012341222",
+            gender="male",
+            birthday=date(1993, 1, 1),
+        )
+        # 리더
+        GroupMember.objects.create(study_group=self.recruitment.study_group, user=self.leader, is_leader=True)
+
+        # 기존 멤버
+        GroupMember.objects.create(study_group=self.recruitment.study_group, user=old_member, is_leader=False)
+
+        with transaction.atomic():
+            app_old = Application.objects.create(
+                recruitment=self.recruitment,
+                user=old_member,
+                objective="파이썬 심화",
+                motivation="깊게 배우고 싶어서",
+                self_introduction="열심히 하겠습니다",
+                available_time="주중 저녁",
+                has_study_experience=False,
+                status=Application.ApplicationStatus.PENDING,
+            )
+
+        with transaction.atomic():
+            app_old.status = Application.ApplicationStatus.ACCEPTED
+            app_old.save(update_fields=["status"])
+
+        # 신규 멤버 accept
+        with transaction.atomic():
+            app_new = Application.objects.create(
+                recruitment=self.recruitment,
+                user=self.applicant,
+                objective="파이썬 심화2",
+                motivation="깊게 배우고 싶어서2",
+                self_introduction="열심히 하겠습니다2",
+                available_time="주중 저녁2",
+                has_study_experience=False,
+                status=Application.ApplicationStatus.PENDING,
+            )
+
+        with transaction.atomic():
+            app_new.status = Application.ApplicationStatus.ACCEPTED
+            app_new.save(update_fields=["status"])
+
+        notifs = Notification.objects.filter(
+            notification_type=Notification.NotificationType.STUDY_JOIN,
+        )
+        self.assertGreaterEqual(notifs.count(), 2)  # 기존 멤버(old_member)와 그룹 리더(self.leader)에게 알림 생성
+
+        recipients = set(notifs.values_list("user_id", flat=True))
+        self.assertIn(old_member.id, recipients)
+        self.assertIn(self.leader.id, recipients)
+        self.assertNotIn(self.applicant.id, recipients)
+
+        n_old = notifs.filter(user_id=old_member.id).first()
+        assert n_old is not None  # mypy
+        self.assertIn(self.recruitment.study_group.name, n_old.content)
+        self.assertIn(self.applicant.nickname, n_old.content)
+        group_id = self.recruitment.study_group_id
+        self.assertEqual(n_old.back_url_link, f"/study-groups/{group_id}/chat")

--- a/apps/notifications/tests/test_notification_create.py
+++ b/apps/notifications/tests/test_notification_create.py
@@ -114,7 +114,7 @@ class NotificationOnApplicationCreateTests(TransactionTestCase):
         n = notifs.first()
         assert n is not None  # mypy
         self.assertIn(self.recruitment.title, n.content)
-        self.assertEqual(n.back_url_link, "/applications/me")
+        self.assertEqual(n.back_url_link, "/my-page/applications")
 
         # 같은 상태로 한 번 더 저장해도 추가 생성되지 않음(중복 방지)
         with transaction.atomic():
@@ -154,7 +154,7 @@ class NotificationOnApplicationCreateTests(TransactionTestCase):
         n = notifs.first()
         assert n is not None
         self.assertIn(self.recruitment.title, n.content)
-        self.assertEqual(n.back_url_link, "/applications/me")
+        self.assertEqual(n.back_url_link, "/my-page/applications")
 
         # 같은 상태로 한 번 더 저장해도 추가 생성되지 않음(중복 방지)
         with transaction.atomic():


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #116
- 작업 요약: 특정 로그인 유저의 지원 내역이 승인되면 기존에 참여한 스터디 그룹원들에게 새로운 유저가 참여했다는 알림이 발생, 알림 수신자가 해당 알림을 클릭하면 해당 스터디 그룹 채팅방으로 이동

## 📄 상세 내용
- [x] 신청 상태 accept 시 그룹원에게 알림 발생 리시버 작성
- [x] 서비스 레이어에서 기존 참여 멤버 및 신규 참여 인원에겐 제외한 알림 발생 로직 작성
- [x] 관련 테스트코드 작성

## 📸 스크린샷 (선택)
<img width="1830" height="986" alt="image" src="https://github.com/user-attachments/assets/6b14b189-b4e4-4534-a337-802e224f4cb0" />

## 📝 기타 참고 사항
비동기 백그라운드 테스크 및 sse 연동은 추후 예정

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
