### PR TITLE
[Feature/withdrawal] 탈퇴한 계정을 복구하는 API

### DIFF
--- a/apps/users/models/withdrawals.py
+++ b/apps/users/models/withdrawals.py
@@ -19,12 +19,12 @@ class WithdrawalsReasonChoices(models.TextChoices):
 
 
 class Withdrawals(BaseModel):
-    user = models.OneToOneField("users.User", on_delete=models.CASCADE, unique=True, help_text="유저")
+    user = models.OneToOneField("users.User", on_delete=models.CASCADE, unique=True, help_text="유저")  # 중복 요청 방지
     reason = models.CharField(
         max_length=30, choices=WithdrawalsReasonChoices.choices, null=False, blank=False, help_text="탈퇴 사유"
     )
     reason_detail = models.CharField(max_length=500, null=False, blank=False, help_text="구체적인 탈퇴 사유")
-    due_date = models.DateField(null=False, blank=False, help_text="계정 삭제 예정일")
+    due_date = models.DateField(null=False, blank=False, help_text="계정 삭제 예정일")  # 유예 기간
 
     objects = WithdrawalUserManager()
 

--- a/apps/users/serializers/withdrawals.py
+++ b/apps/users/serializers/withdrawals.py
@@ -1,3 +1,5 @@
+# apps/users/serializers/withdrawals.py
+
 from typing import Any, Dict
 
 from rest_framework import serializers
@@ -13,6 +15,7 @@ class WithdrawalRequestSerializer(serializers.ModelSerializer[Withdrawals]):
         model = Withdrawals
         fields = ("user", "reason", "reason_detail")
 
+    # user는 validated_data에 자동으로 포함됨
     def validate(self, data: Dict[str, Any]) -> Dict[str, Any]:
         user = data["user"]
         if not self.instance and Withdrawals.objects.filter(user=user).exists():
@@ -26,3 +29,9 @@ class WithdrawalResponseSerializer(serializers.ModelSerializer[Withdrawals]):
     class Meta:
         model = Withdrawals
         fields = ("user", "reason", "reason_detail", "due_date", "created_at", "updated_at")
+
+
+class AccountRecoverySerializer(serializers.ModelSerializer[Withdrawals]):
+    # 복구 코드 입력 검증
+    # email 정의 안 하는 이유: request.user.email을 그대로 쓰는 게 Django가 권장하는 방식인 듯
+    code = serializers.CharField()

--- a/apps/users/serializers/withdrawals.py
+++ b/apps/users/serializers/withdrawals.py
@@ -31,7 +31,7 @@ class WithdrawalResponseSerializer(serializers.ModelSerializer[Withdrawals]):
         fields = ("user", "reason", "reason_detail", "due_date", "created_at", "updated_at")
 
 
-class AccountRecoverySerializer(serializers.ModelSerializer[Withdrawals]):
-    # 복구 코드 입력 검증
-    # email 정의 안 하는 이유: request.user.email을 그대로 쓰는 게 Django가 권장하는 방식인 듯
+class AccountRecoverySerializer(serializers.Serializer[Withdrawals]):
+    # 복구 코드 입력 검증용
+    # email 정의 안 하는 이유: request.user.email을 그대로 쓰는 게 Django가 권장하는 방식으로 보임
     code = serializers.CharField()

--- a/apps/users/serializers/withdrawals.py
+++ b/apps/users/serializers/withdrawals.py
@@ -30,8 +30,9 @@ class WithdrawalResponseSerializer(serializers.ModelSerializer[Withdrawals]):
         model = Withdrawals
         fields = ("user", "reason", "reason_detail", "due_date", "created_at", "updated_at")
 
+    # 복구 코드 입력 검증용
+
 
 class AccountRecoverySerializer(serializers.Serializer[Withdrawals]):
-    # 복구 코드 입력 검증용
-    # email 정의 안 하는 이유: request.user.email을 그대로 쓰는 게 Django가 권장하는 방식으로 보임
-    code = serializers.CharField()
+    email = serializers.EmailField()
+    verification_code = serializers.CharField()

--- a/apps/users/serializers/withdrawals.py
+++ b/apps/users/serializers/withdrawals.py
@@ -30,8 +30,6 @@ class WithdrawalResponseSerializer(serializers.ModelSerializer[Withdrawals]):
         model = Withdrawals
         fields = ("user", "reason", "reason_detail", "due_date", "created_at", "updated_at")
 
-    # 복구 코드 입력 검증용
-
 
 class AccountRecoverySerializer(serializers.Serializer[Withdrawals]):
     email = serializers.EmailField()

--- a/apps/users/serializers/withdrawals_serializer.py
+++ b/apps/users/serializers/withdrawals_serializer.py
@@ -1,4 +1,4 @@
-# apps/users/serializers/withdrawals.py
+# apps/users/serializers/withdrawals_serializer.py
 
 from typing import Any, Dict
 

--- a/apps/users/services/withdrawals.py
+++ b/apps/users/services/withdrawals.py
@@ -4,7 +4,6 @@ from datetime import date, timedelta
 
 from apps.users.models.user import User
 from apps.users.models.withdrawals import Withdrawals
-from django.core.exceptions import ObjectDoesNotExist
 
 
 def create_withdrawal(user: User, reason: str, reason_detail: str) -> Withdrawals:
@@ -16,31 +15,30 @@ def create_withdrawal(user: User, reason: str, reason_detail: str) -> Withdrawal
     # 비즈니스 로직 1: 탈퇴 처리 마감일은 14일 뒤로 설정
     due_date = date.today() + timedelta(days=14)
 
-    # 비즈니스 로직 2: 모델 객체 생성(탈퇴 요청 생성)
-    # withdrawal 모델에 탈퇴 요청 저장
+    # 비즈니스 로직 2: 모델 객체 생성(탈퇴 요청 생성) 후 withdrawal 모델에 탈퇴 요청 저장
     withdrawal = Withdrawals.objects.create(user=user, reason=reason, reason_detail=reason_detail, due_date=due_date)
 
     return withdrawal
 
 
-def recover_account(email: str, verification_code: str) -> User | None:
+def recover_account(email: str, verification_code: str) -> User:
     """
     인증 코드 검증 후 유저 계정을 복구하고 탈퇴 요청을 삭제.
     """
 
-    # 탈퇴 요청한 유저 조회
-    withdrawal = Withdrawals.objects.select_related("user").filter(user_email=email).first()
+    # 1) 탈퇴 요청한 유저 조회: user(id)로 user의 email 찾기
+    withdrawal = Withdrawals.objects.select_related("user").filter(user__email=email).first()
 
-    # 탈퇴 요청이 없다면 Error 반환: 추후 오류 처리를 위한 ObjectDoesNotExist 예외 사용
+    # 1-1) 탈퇴 요청이 없다면 Error 반환: 추후 오류 처리를 위한 DoesNotExist 예외 사용
     if not withdrawal:
-        raise ObjectDoesNotExist("해당 이메일로 탈퇴 요청이 존재하지 않습니다.")
+        raise Withdrawals.DoesNotExist("해당 이메일로 탈퇴 요청이 존재하지 않습니다.")
 
-    # 유저 계정 복구 및 탈퇴 요청 삭제
-    # 탈퇴 요청만 삭제하는 거고 user 모델의 상태는 변경하지 않음
-    # 따라서 user.is_active = True를 명시적으로 설정
+    # 2) 유저 계정 복구: 탈퇴 요청만 삭제하는 거고 user 모델의 상태는 변경하지 않으므로 user.is_active = True를 명시적으로 설정
     user = withdrawal.user
     user.is_active = True
     user.save()
-    # withdrawal.delete()
+
+    # 3) 탈퇴 요청 삭제: withdrawal 모델에서 해당 user를 삭제
+    withdrawal.delete()
 
     return user

--- a/apps/users/services/withdrawals.py
+++ b/apps/users/services/withdrawals.py
@@ -4,7 +4,7 @@ from datetime import date, timedelta
 
 from apps.users.models.user import User
 from apps.users.models.withdrawals import Withdrawals
-from apps.users.services.email_service import EmailVerificationService
+from django.core.exceptions import ObjectDoesNotExist
 
 
 def create_withdrawal(user: User, reason: str, reason_detail: str) -> Withdrawals:
@@ -18,39 +18,29 @@ def create_withdrawal(user: User, reason: str, reason_detail: str) -> Withdrawal
 
     # 비즈니스 로직 2: 모델 객체 생성(탈퇴 요청 생성)
     # withdrawal 모델에 탈퇴 요청 저장
-    # user.is_active는 views에서 처리(validate에서 처리하지 않는 이유: user가 비활성화된 상태일 수도 있기 때문) < 이거 자꾸 자동 완성되는데 뭐지
     withdrawal = Withdrawals.objects.create(user=user, reason=reason, reason_detail=reason_detail, due_date=due_date)
 
     return withdrawal
 
 
-def recover_account(email: str, code: str) -> User | None:
+def recover_account(email: str, verification_code: str) -> User | None:
     """
     인증 코드 검증 후 유저 계정을 복구하고 탈퇴 요청을 삭제.
     """
 
     # 탈퇴 요청한 유저 조회
-    withdrawal = Withdrawals.objects.select_related("user").filter(user__email=email).first()
+    withdrawal = Withdrawals.objects.select_related("user").filter(user_email=email).first()
 
-    # 탈퇴 요청이 없다면 None 반환
+    # 탈퇴 요청이 없다면 Error 반환: 추후 오류 처리를 위한 ObjectDoesNotExist 예외 사용
     if not withdrawal:
-        return None
-
-    user = withdrawal.user
-
-    # 인증 코드 검증
-    email_service = EmailVerificationService()
-    verification_result = email_service.verify_code(email=email, code=code, purpose="recover_account")
-
-    # 인증 코드가 유효하지 않다면 None 반환
-    if verification_result.status_code != 200:
-        return None
+        raise ObjectDoesNotExist("해당 이메일로 탈퇴 요청이 존재하지 않습니다.")
 
     # 유저 계정 복구 및 탈퇴 요청 삭제
     # 탈퇴 요청만 삭제하는 거고 user 모델의 상태는 변경하지 않음
     # 따라서 user.is_active = True를 명시적으로 설정
+    user = withdrawal.user
     user.is_active = True
     user.save()
-    withdrawal.delete()
+    # withdrawal.delete()
 
     return user

--- a/apps/users/services/withdrawals.py
+++ b/apps/users/services/withdrawals.py
@@ -1,7 +1,10 @@
+# apps/users/services/withdrawals.py
+
 from datetime import date, timedelta
 
 from apps.users.models.user import User
 from apps.users.models.withdrawals import Withdrawals
+from apps.users.services.email_service import EmailVerificationService
 
 
 def create_withdrawal(user: User, reason: str, reason_detail: str) -> Withdrawals:
@@ -13,7 +16,41 @@ def create_withdrawal(user: User, reason: str, reason_detail: str) -> Withdrawal
     # 비즈니스 로직 1: 탈퇴 처리 마감일은 14일 뒤로 설정
     due_date = date.today() + timedelta(days=14)
 
-    # 비즈니스 로직 2: 모델 객체 생성
+    # 비즈니스 로직 2: 모델 객체 생성(탈퇴 요청 생성)
+    # withdrawal 모델에 탈퇴 요청 저장
+    # user.is_active는 views에서 처리(validate에서 처리하지 않는 이유: user가 비활성화된 상태일 수도 있기 때문) < 이거 자꾸 자동 완성되는데 뭐지
     withdrawal = Withdrawals.objects.create(user=user, reason=reason, reason_detail=reason_detail, due_date=due_date)
 
     return withdrawal
+
+
+def recover_account(email: str, code: str) -> User | None:
+    """
+    인증 코드 검증 후 유저 계정을 복구하고 탈퇴 요청을 삭제.
+    """
+
+    # 탈퇴 요청한 유저 조회
+    withdrawal = Withdrawals.objects.select_related("user").filter(user__email=email).first()
+
+    # 탈퇴 요청이 없다면 None 반환
+    if not withdrawal:
+        return None
+
+    user = withdrawal.user
+
+    # 인증 코드 검증
+    email_service = EmailVerificationService()
+    verification_result = email_service.verify_code(email=email, code=code, purpose="recover_account")
+
+    # 인증 코드가 유효하지 않다면 None 반환
+    if verification_result.status_code != 200:
+        return None
+
+    # 유저 계정 복구 및 탈퇴 요청 삭제
+    # 탈퇴 요청만 삭제하는 거고 user 모델의 상태는 변경하지 않음
+    # 따라서 user.is_active = True를 명시적으로 설정
+    user.is_active = True
+    user.save()
+    withdrawal.delete()
+
+    return user

--- a/apps/users/services/withdrawals_service.py
+++ b/apps/users/services/withdrawals_service.py
@@ -23,7 +23,7 @@ def create_withdrawal(user: User, reason: str, reason_detail: str) -> Withdrawal
     return withdrawal
 
 
-def recover_account(email: str) -> None:
+def recover_account(email: str, verification_code: str) -> None:
     """
     인증 코드 검증 후 유저 계정을 복구하고 탈퇴 요청을 삭제.
     """

--- a/apps/users/services/withdrawals_service.py
+++ b/apps/users/services/withdrawals_service.py
@@ -2,6 +2,8 @@
 
 from datetime import date, timedelta
 
+from django.db import transaction
+
 from apps.users.models.user import User
 from apps.users.models.withdrawals import Withdrawals
 
@@ -21,7 +23,7 @@ def create_withdrawal(user: User, reason: str, reason_detail: str) -> Withdrawal
     return withdrawal
 
 
-def recover_account(email: str, verification_code: str) -> User:
+def recover_account(email: str) -> None:
     """
     인증 코드 검증 후 유저 계정을 복구하고 탈퇴 요청을 삭제.
     """
@@ -33,12 +35,9 @@ def recover_account(email: str, verification_code: str) -> User:
     if not withdrawal:
         raise Withdrawals.DoesNotExist("해당 이메일로 탈퇴 요청이 존재하지 않습니다.")
 
-    # 2) 유저 계정 복구: 탈퇴 요청만 삭제하는 거고 user 모델의 상태는 변경하지 않으므로 user.is_active = True를 명시적으로 설정
-    user = withdrawal.user
-    user.is_active = True
-    user.save()
-
-    # 3) 탈퇴 요청 삭제: withdrawal 모델에서 해당 user를 삭제
-    withdrawal.delete()
-
-    return user
+    # 2) 유저 계정 복구와 탈퇴 요청 삭제: 탈퇴 요청만 삭제하는 거고 user 모델의 상태는 변경하지 않으므로 user.is_active = True를 명시적으로 설정
+    with transaction.atomic():
+        user = withdrawal.user
+        user.is_active = True
+        user.save()
+        withdrawal.delete()

--- a/apps/users/services/withdrawals_service.py
+++ b/apps/users/services/withdrawals_service.py
@@ -1,4 +1,4 @@
-# apps/users/services/withdrawals.py
+# apps/users/services/withdrawals_service.py
 
 from datetime import date, timedelta
 

--- a/apps/users/tests/test_withdrawals.py
+++ b/apps/users/tests/test_withdrawals.py
@@ -1,6 +1,7 @@
 from django.core.cache import cache
 from django.urls import reverse
 from rest_framework import status
+from rest_framework.response import Response
 from rest_framework.test import APITestCase
 
 from apps.core.tests.mixins.test_user_mixins import EmailVerificationMixin
@@ -17,9 +18,9 @@ class UserWithdrawalJWTAPITest(APITestCase, EmailVerificationMixin):
     # 클래스 메소드: 테스트 클래스 전체에서 공유하는 데이터 설정
     def setUpTestData(cls) -> None:
         cls.user = cls._create_test_user()  # 유저 생성
-        cls.client.force_authenticate(user=cls.user)
 
     def setUp(self) -> None:
+        self.client.force_authenticate(user=self.user)
         self.url = reverse("account_withdrawals")  # mypy 에러 방지용
 
     def test_successful_withdrawal_request(self) -> None:
@@ -69,44 +70,51 @@ class UserRecoveryJWTAPITest(APITestCase, EmailVerificationMixin):
     @classmethod
     def setUpTestData(cls) -> None:
         cls.user = cls._create_test_user()  # 유저 생성
-        cls.client.force_authenticate(user=cls.user)
 
     def setUp(self) -> None:
-        self.url = reverse("account_recovery")  # mypy 에러 방지용
+        self.client.force_authenticate(user=self.user)
+        self.withdrawal_url = reverse("account_withdrawals")  # mypy 에러 방지용
+        self.recovery_url = reverse("account_recovery")  # mypy 에러 방지용
 
-    # 인증 코드 설정(code: str은 나중에 123456 대신 실제 코드로 변경할 가능성을 위해 남겨 둠)
-    def _set_verification_code(self, email: str, code: str, purpose: VerificationPurpose) -> None:
-        cache.clear()  # 인증 코드 설정하는 캐시 초기화
-        cache_key = f"{purpose.RECOVER_ACCOUNT}: {email}"
-        cache.set(cache_key, 123456, timeout=300)  # 5분 동안 유효
-
-    def test_account_withdrawal_request(self) -> None:
-        # EmailVerificationMixin을 통해 인증 코드 미리 세팅
-        self._set_verification_code(self.user.email, "123456", VerificationPurpose.RECOVER_ACCOUNT)
-
-        # 1) 탈퇴 요청을 생성
+    # * 탈퇴 요청한 유저 생성
+    def _test_successful_withdrawal_request(self) -> Response:
+        self.client.force_authenticate(user=self.user)
         data = {
             "reason": WithdrawalsReasonChoices.PRIVACY_CONCERNS,
             "reason_detail": "개인정보/보안/우려",
         }
-        response = self.client.post(self.url, data)
-        # response = self.client.post(self.send_url, {"email": (email := self.test_email)})
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.client.post(self.withdrawal_url, data)
+        self.client.force_authenticate(user=None)
+        return response
 
+    # * 인증 코드 설정
+    def _set_verification_code(self, email: str, code: str, purpose: VerificationPurpose) -> None:
+        cache.clear()  # 인증 코드 설정하는 캐시 초기화
+        cache_key = f"{purpose}-{email}"
+        cache.set(cache_key, code, timeout=300)  # 5분 동안 유효
+
+    # * 탈퇴 복구
     def test_account_recovery_request(self) -> None:
-        # 2) 탈퇴 신청을 번복(계정 복구 요청)
+        # 1) 탈퇴 요청을 생성
+        self._test_successful_withdrawal_request()
+
+        # 2) EmailVerificationMixin을 통해 인증 코드 세팅
+        self._set_verification_code(self.user.email, "123456", VerificationPurpose.RECOVER_ACCOUNT)
+
+        # 3) 탈퇴 신청을 번복(계정 복구 요청)
         data = {
             "email": self.user.email,
-            "verification_code": "123456",  # 테스트용 코드
+            "verification_code": "123456",
         }
 
-        response = self.client.post(self.url, data)
+        response = self.client.post(self.recovery_url, data)
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["detail"], "계정이 복구되었습니다. 이제 로그인할 수 있습니다.")
 
-        # 3) 유저 계정 활성화 확인
+        # 4) 유저 계정 활성화 확인
         self.user.refresh_from_db()
         self.assertTrue(self.user.is_active)
 
-        # 4) Withdrawals 레코드 삭제 확인
+        # 5) Withdrawals 레코드에서 해당 유저가 삭제되었는지 확인
         self.assertFalse(Withdrawals.objects.filter(user=self.user).exists())

--- a/apps/users/tests/test_withdrawals.py
+++ b/apps/users/tests/test_withdrawals.py
@@ -4,12 +4,12 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.test import APITestCase
 
-from apps.core.tests.mixins.test_user_mixins import EmailVerificationMixin
+from apps.core.tests.mixins.test_user_mixins import VerificationMixin
 from apps.users.models.withdrawals import Withdrawals, WithdrawalsReasonChoices
 from apps.users.utils.enums import VerificationPurpose
 
 
-class UserWithdrawalJWTAPITest(APITestCase, EmailVerificationMixin):
+class UserWithdrawalJWTAPITest(APITestCase, VerificationMixin):
     """
     회원 탈퇴 요청 API 테스트
     """
@@ -66,7 +66,7 @@ class UserWithdrawalJWTAPITest(APITestCase, EmailVerificationMixin):
         self.assertEqual(error_detail.code, "error")
 
 
-class UserRecoveryJWTAPITest(APITestCase, EmailVerificationMixin):
+class UserRecoveryJWTAPITest(APITestCase, VerificationMixin):
     @classmethod
     def setUpTestData(cls) -> None:
         cls.user = cls._create_test_user()  # 유저 생성

--- a/apps/users/tests/test_withdrawals.py
+++ b/apps/users/tests/test_withdrawals.py
@@ -1,7 +1,8 @@
+from datetime import date, timedelta
+
 from django.core.cache import cache
 from django.urls import reverse
 from rest_framework import status
-from rest_framework.response import Response
 from rest_framework.test import APITestCase
 
 from apps.core.tests.mixins.test_user_mixins import VerificationMixin
@@ -76,17 +77,6 @@ class UserRecoveryJWTAPITest(APITestCase, VerificationMixin):
         self.withdrawal_url = reverse("account_withdrawals")  # mypy 에러 방지용
         self.recovery_url = reverse("account_recovery")  # mypy 에러 방지용
 
-    # * 탈퇴 요청한 유저 생성
-    def _test_successful_withdrawal_request(self) -> Response:
-        self.client.force_authenticate(user=self.user)
-        data = {
-            "reason": WithdrawalsReasonChoices.PRIVACY_CONCERNS,
-            "reason_detail": "개인정보/보안/우려",
-        }
-        response = self.client.post(self.withdrawal_url, data)
-        self.client.force_authenticate(user=None)
-        return response
-
     # * 인증 코드 설정
     def _set_verification_code(self, email: str, code: str, purpose: VerificationPurpose) -> None:
         cache.clear()  # 인증 코드 설정하는 캐시 초기화
@@ -96,7 +86,12 @@ class UserRecoveryJWTAPITest(APITestCase, VerificationMixin):
     # * 탈퇴 복구
     def test_account_recovery_request(self) -> None:
         # 1) 탈퇴 요청을 생성
-        self._test_successful_withdrawal_request()
+        Withdrawals.objects.create(
+            user=self.user,
+            reason=WithdrawalsReasonChoices.PRIVACY_CONCERNS,
+            reason_detail="개인정보/보안/우려",
+            due_date=date.today() + timedelta(days=14),
+        )
 
         # 2) EmailVerificationMixin을 통해 인증 코드 세팅
         self._set_verification_code(self.user.email, "123456", VerificationPurpose.RECOVER_ACCOUNT)

--- a/apps/users/tests/test_withdrawals.py
+++ b/apps/users/tests/test_withdrawals.py
@@ -1,19 +1,32 @@
+from django.core.cache import cache
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from apps.core.tests.mixins.test_user_mixins import TestUserMixin
+from apps.core.tests.mixins.test_user_mixins import EmailVerificationMixin
 from apps.users.models.withdrawals import Withdrawals, WithdrawalsReasonChoices
+from apps.users.utils.enums import VerificationPurpose
 
 
-class UserWithdrawalJWTAPITest(APITestCase, TestUserMixin):
+class UserWithdrawalJWTAPITest(APITestCase, EmailVerificationMixin):
+    """
+    회원 탈퇴 요청 API 테스트
+    """
+
+    @classmethod
+    # 클래스 메소드: 테스트 클래스 전체에서 공유하는 데이터 설정
+    def setUpTestData(cls) -> None:
+        cls.user = cls._create_test_user()  # 유저 생성
+        cls.client.force_authenticate(user=cls.user)
+
     def setUp(self) -> None:
-        self.user = self._create_test_user()
-        self.url = reverse("account_withdrawals")
-        self.client.force_authenticate(user=self.user)
+        self.url = reverse("account_withdrawals")  # mypy 에러 방지용
 
     def test_successful_withdrawal_request(self) -> None:
-        data = {"reason": WithdrawalsReasonChoices.PRIVACY_CONCERNS, "reason_detail": "개인정보/보안/우려"}
+        data = {
+            "reason": WithdrawalsReasonChoices.PRIVACY_CONCERNS,
+            "reason_detail": "개인정보/보안/우려",
+        }  # 요청 데이터
         response = self.client.post(self.url, data)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -30,8 +43,8 @@ class UserWithdrawalJWTAPITest(APITestCase, TestUserMixin):
         self.user.refresh_from_db()
         self.assertFalse(self.user.is_active)
 
-    # 이미 탈퇴 요청한 사용자: 중복 요청
     def test_duplicate_withdrawal_request(self) -> None:
+        # 첫 번째 탈퇴 요청(정상적)
         first_data = {
             "reason": WithdrawalsReasonChoices.PRIVACY_CONCERNS,
             "reason_detail": "첫 요청",
@@ -39,6 +52,7 @@ class UserWithdrawalJWTAPITest(APITestCase, TestUserMixin):
         first_response = self.client.post(self.url, first_data)
         self.assertEqual(first_response.status_code, status.HTTP_200_OK)
 
+        # 두 번째 중복 요청(비정상적)
         second_data = {
             "reason": WithdrawalsReasonChoices.PRIVACY_CONCERNS,
             "reason_detail": "테스트용 중복 요청",
@@ -47,6 +61,52 @@ class UserWithdrawalJWTAPITest(APITestCase, TestUserMixin):
         self.assertEqual(second_response.status_code, status.HTTP_400_BAD_REQUEST)
 
         error_detail = second_response.data["non_field_errors"][0]
-
         self.assertEqual(str(error_detail), "이미 탈퇴 요청이 존재합니다.")
         self.assertEqual(error_detail.code, "error")
+
+
+class UserRecoveryJWTAPITest(APITestCase, EmailVerificationMixin):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.user = cls._create_test_user()  # 유저 생성
+        cls.client.force_authenticate(user=cls.user)
+
+    def setUp(self) -> None:
+        self.url = reverse("account_recovery")  # mypy 에러 방지용
+
+    # 인증 코드 설정(code: str은 나중에 123456 대신 실제 코드로 변경할 가능성을 위해 남겨 둠)
+    def _set_verification_code(self, email: str, code: str, purpose: VerificationPurpose) -> None:
+        cache.clear()  # 인증 코드 설정하는 캐시 초기화
+        cache_key = f"{purpose.RECOVER_ACCOUNT}: {email}"
+        cache.set(cache_key, 123456, timeout=300)  # 5분 동안 유효
+
+    def test_account_withdrawal_request(self) -> None:
+        # 1) 먼저 탈퇴 요청을 생성
+        data = {
+            "reason": WithdrawalsReasonChoices.PRIVACY_CONCERNS,
+            "reason_detail": "개인정보/보안/우려",
+        }
+        response = self.client.post(self.url, data)
+        # response = self.client.post(self.send_url, {"email": (email := self.test_email)})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_account_recovery_request(self) -> None:
+        # 2) 탈퇴 신청을 번복(계정 복구 요청)
+        data = {
+            "email": self.user.email,
+            "verification_code": "123456",  # 테스트용 코드
+        }
+
+        # EmailVerificationMixin을 통해 인증 코드 미리 세팅: 코드는 123456으로 고정
+        self._set_verification_code(self.user.email, "123456", VerificationPurpose.RECOVER_ACCOUNT)
+
+        response = self.client.post(self.url, data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["detail"], "계정이 복구되었습니다. 이제 로그인할 수 있습니다.")
+
+        # 3) 유저 계정 활성화 확인
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.is_active)
+
+        # 4) Withdrawals 레코드 삭제 확인
+        self.assertFalse(Withdrawals.objects.filter(user=self.user).exists())

--- a/apps/users/tests/test_withdrawals.py
+++ b/apps/users/tests/test_withdrawals.py
@@ -81,7 +81,10 @@ class UserRecoveryJWTAPITest(APITestCase, EmailVerificationMixin):
         cache.set(cache_key, 123456, timeout=300)  # 5분 동안 유효
 
     def test_account_withdrawal_request(self) -> None:
-        # 1) 먼저 탈퇴 요청을 생성
+        # EmailVerificationMixin을 통해 인증 코드 미리 세팅
+        self._set_verification_code(self.user.email, "123456", VerificationPurpose.RECOVER_ACCOUNT)
+
+        # 1) 탈퇴 요청을 생성
         data = {
             "reason": WithdrawalsReasonChoices.PRIVACY_CONCERNS,
             "reason_detail": "개인정보/보안/우려",
@@ -96,9 +99,6 @@ class UserRecoveryJWTAPITest(APITestCase, EmailVerificationMixin):
             "email": self.user.email,
             "verification_code": "123456",  # 테스트용 코드
         }
-
-        # EmailVerificationMixin을 통해 인증 코드 미리 세팅: 코드는 123456으로 고정
-        self._set_verification_code(self.user.email, "123456", VerificationPurpose.RECOVER_ACCOUNT)
 
         response = self.client.post(self.url, data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/apps/users/urls/auth_urls.py
+++ b/apps/users/urls/auth_urls.py
@@ -9,7 +9,7 @@ from apps.users.views.email_view import (
     SignUpEmailVerifiCationVerifyAPIView,
 )
 from apps.users.views.phone_view import SendVerificationCodeAPIView, VerifyCodeAPIView
-from apps.users.views.withdrawals import AccountRecoveryAPIView, WithdrawalAPIView
+from apps.users.views.withdrawals_view import AccountRecoveryAPIView, WithdrawalAPIView
 
 urlpatterns = [
     path("auth/email/send-code", SignUpEmailVerificationSendAPIView.as_view(), name="email_send_code"),

--- a/apps/users/urls/auth_urls.py
+++ b/apps/users/urls/auth_urls.py
@@ -9,7 +9,7 @@ from apps.users.views.email_view import (
     SignUpEmailVerifiCationVerifyAPIView,
 )
 from apps.users.views.phone_view import SendVerificationCodeAPIView, VerifyCodeAPIView
-from apps.users.views.withdrawals import WithdrawalAPIView
+from apps.users.views.withdrawals import AccountRecoveryAPIView, WithdrawalAPIView
 
 urlpatterns = [
     path("auth/email/send-code", SignUpEmailVerificationSendAPIView.as_view(), name="email_send_code"),
@@ -31,4 +31,5 @@ urlpatterns = [
     path("auth/phone/send-code", SendVerificationCodeAPIView.as_view(), name="phone_send_code"),
     path("auth/phone/verify-code", VerifyCodeAPIView.as_view(), name="phone_verify_code"),
     path("auth/withdraw", WithdrawalAPIView.as_view(), name="account_withdrawals"),
+    path("auth/recover", AccountRecoveryAPIView.as_view(), name="account_recovery"),
 ]

--- a/apps/users/views/withdrawals.py
+++ b/apps/users/views/withdrawals.py
@@ -6,20 +6,23 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.users.serializers.email_verification_serializers import (
+    EmailVerifyCodeSerializer,
+)
 from apps.users.serializers.withdrawals import (
     WithdrawalRequestSerializer,
-    WithdrawalResponseSerializer, 
+    WithdrawalResponseSerializer,
 )
-from apps.users.services.withdrawals import create_withdrawal, recover_account
 from apps.users.services.email_service import EmailVerificationService
+from apps.users.services.withdrawals import create_withdrawal, recover_account
 from apps.users.utils.enums import VerificationPurpose
-from apps.users.serializers.email_verification_serializers import EmailVerifyCodeSerializer
 
 email_service = EmailVerificationService()
 
+
 class WithdrawalAPIView(APIView):
     def post(self, request: Request) -> Response:
-        assert request.user.is_authenticated # mypy 오류로 인한 검증 코드
+        assert request.user.is_authenticated  # mypy 오류로 인한 검증 코드
         request_serializer = WithdrawalRequestSerializer(data=request.data, context={"request": request})
         request_serializer.is_valid(raise_exception=True)
 
@@ -32,28 +35,31 @@ class WithdrawalAPIView(APIView):
 class AccountRecoveryAPIView(APIView):
     """
     탈퇴 계정 복구 요청 API
-    - 이메일과 인증 코드 검증
-    - 복구 성공 시 계정 활성화 및 탈퇴 요청 삭제
+    └ 이메일과 인증 코드 검증
+    └ 복구 성공 시 계정 활성화 및 탈퇴 요청 삭제
     """
 
     def post(self, request: Request) -> Response:
+
         # 1) 유효성 검증
         serializer = EmailVerifyCodeSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
         # 2) 저장된 캐시 불러오기(enum.py)
         purpose = VerificationPurpose.RECOVER_ACCOUNT
-        
+
         try:
             # 3) 인증 코드 검증
-            email_service.verify_code(purpose, **serializer.validated_data) # 검증 코드 호출
+            email_service.verify_code(purpose, **serializer.validated_data)  # 검증 코드 호출
 
             # 4) 계정 복구
             user = recover_account(**serializer.validated_data)
 
             # 5) 성공 응답
             return Response({"detail": "계정이 복구되었습니다. 이제 로그인할 수 있습니다."}, status=status.HTTP_200_OK)
-        
+
         # 6) 실패 응답(오류 제어는 나중에)
         except Exception as e:
-            return Response({"detail": f"알 수 없는 오류가 발생했습니다. {str(e)}."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"detail": f"알 수 없는 오류가 발생했습니다. {str(e)}."}, status=status.HTTP_400_BAD_REQUEST
+            )

--- a/apps/users/views/withdrawals.py
+++ b/apps/users/views/withdrawals.py
@@ -1,7 +1,7 @@
 # apps/users/views/withdrawals.py
 
 from rest_framework import status
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -33,6 +33,7 @@ class WithdrawalAPIView(APIView):
 
 
 class AccountRecoveryAPIView(APIView):
+    permission_classes = [AllowAny]
     """
     탈퇴 계정 복구 요청 API
     └ 이메일과 인증 코드 검증
@@ -40,7 +41,6 @@ class AccountRecoveryAPIView(APIView):
     """
 
     def post(self, request: Request) -> Response:
-
         # 1) 유효성 검증
         serializer = EmailVerifyCodeSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)

--- a/apps/users/views/withdrawals.py
+++ b/apps/users/views/withdrawals.py
@@ -1,3 +1,5 @@
+# apps/users/views/withdrawals.py
+
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -5,10 +7,11 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.users.serializers.withdrawals import (
+    AccountRecoverySerializer,
     WithdrawalRequestSerializer,
     WithdrawalResponseSerializer,
 )
-from apps.users.services.withdrawals import create_withdrawal
+from apps.users.services.withdrawals import create_withdrawal, recover_account
 
 
 class WithdrawalAPIView(APIView):
@@ -21,3 +24,25 @@ class WithdrawalAPIView(APIView):
 
         response_serializer = WithdrawalResponseSerializer(instance=withdrawal_instance)
         return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+
+class AccountRecoveryAPIView(APIView):
+    """
+    탈퇴 계정 복구 요청 API
+    - 이메일과 인증 코드 검증
+    - 복구 성공 시 계정 활성화 및 탈퇴 요청 삭제
+    - 복구 실패 시 에러 응답 반환
+    """
+
+    def post(self, request: Request) -> Response:
+        serializer = AccountRecoverySerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        email = serializer.validated_data["email"]
+        code = serializer.validated_data["code"]
+
+        user = recover_account(email=email, code=code)
+        if not user:
+            return Response({"error": "계정 복구에 실패했습니다."}, status=status.HTTP_400_BAD_REQUEST)
+
+        return Response({"detail": "계정이 복구되었습니다. 이제 로그인할 수 있습니다."}, status=status.HTTP_200_OK)

--- a/apps/users/views/withdrawals.py
+++ b/apps/users/views/withdrawals.py
@@ -7,16 +7,19 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.users.serializers.withdrawals import (
-    AccountRecoverySerializer,
     WithdrawalRequestSerializer,
-    WithdrawalResponseSerializer,
+    WithdrawalResponseSerializer, 
 )
 from apps.users.services.withdrawals import create_withdrawal, recover_account
+from apps.users.services.email_service import EmailVerificationService
+from apps.users.utils.enums import VerificationPurpose
+from apps.users.serializers.email_verification_serializers import EmailVerifyCodeSerializer
 
+email_service = EmailVerificationService()
 
 class WithdrawalAPIView(APIView):
     def post(self, request: Request) -> Response:
-        assert request.user.is_authenticated  # mypy 오류로 인한 검증 코드
+        assert request.user.is_authenticated # mypy 오류로 인한 검증 코드
         request_serializer = WithdrawalRequestSerializer(data=request.data, context={"request": request})
         request_serializer.is_valid(raise_exception=True)
 
@@ -31,18 +34,26 @@ class AccountRecoveryAPIView(APIView):
     탈퇴 계정 복구 요청 API
     - 이메일과 인증 코드 검증
     - 복구 성공 시 계정 활성화 및 탈퇴 요청 삭제
-    - 복구 실패 시 에러 응답 반환
     """
 
     def post(self, request: Request) -> Response:
-        serializer = AccountRecoverySerializer(data=request.data)
+        # 1) 유효성 검증
+        serializer = EmailVerifyCodeSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        email = serializer.validated_data["email"]
-        code = serializer.validated_data["code"]
+        # 2) 저장된 캐시 불러오기(enum.py)
+        purpose = VerificationPurpose.RECOVER_ACCOUNT
+        
+        try:
+            # 3) 인증 코드 검증
+            email_service.verify_code(purpose, **serializer.validated_data) # 검증 코드 호출
 
-        user = recover_account(email=email, code=code)
-        if not user:
-            return Response({"error": "계정 복구에 실패했습니다."}, status=status.HTTP_400_BAD_REQUEST)
+            # 4) 계정 복구
+            user = recover_account(**serializer.validated_data)
 
-        return Response({"detail": "계정이 복구되었습니다. 이제 로그인할 수 있습니다."}, status=status.HTTP_200_OK)
+            # 5) 성공 응답
+            return Response({"detail": "계정이 복구되었습니다. 이제 로그인할 수 있습니다."}, status=status.HTTP_200_OK)
+        
+        # 6) 실패 응답(오류 제어는 나중에)
+        except Exception as e:
+            return Response({"detail": f"알 수 없는 오류가 발생했습니다. {str(e)}."}, status=status.HTTP_400_BAD_REQUEST)

--- a/apps/users/views/withdrawals_view.py
+++ b/apps/users/views/withdrawals_view.py
@@ -1,4 +1,4 @@
-# apps/users/views/withdrawals.py
+# apps/users/views/withdrawals_view.py
 
 from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -9,12 +9,12 @@ from rest_framework.views import APIView
 from apps.users.serializers.email_verification_serializers import (
     EmailVerifyCodeSerializer,
 )
-from apps.users.serializers.withdrawals import (
+from apps.users.serializers.withdrawals_serializer import (
     WithdrawalRequestSerializer,
     WithdrawalResponseSerializer,
 )
 from apps.users.services.email_service import EmailVerificationService
-from apps.users.services.withdrawals import create_withdrawal, recover_account
+from apps.users.services.withdrawals_service import create_withdrawal, recover_account
 from apps.users.utils.enums import VerificationPurpose
 
 email_service = EmailVerificationService()

--- a/apps/users/views/withdrawals_view.py
+++ b/apps/users/views/withdrawals_view.py
@@ -6,6 +6,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.users.models.withdrawals import Withdrawals
 from apps.users.serializers.email_verification_serializers import (
     EmailVerifyCodeSerializer,
 )
@@ -14,6 +15,10 @@ from apps.users.serializers.withdrawals_serializer import (
     WithdrawalResponseSerializer,
 )
 from apps.users.services.email_service import EmailVerificationService
+from apps.users.services.exceptions import (
+    EmailSendingFailedError,
+    EmailVerificationCodeFailedError,
+)
 from apps.users.services.withdrawals_service import create_withdrawal, recover_account
 from apps.users.utils.enums import VerificationPurpose
 
@@ -45,7 +50,7 @@ class AccountRecoveryAPIView(APIView):
         serializer = EmailVerifyCodeSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        # 2) 저장된 캐시 불러오기(enum.py)
+        # 2) 이 인증의 목적을 설정
         purpose = VerificationPurpose.RECOVER_ACCOUNT
 
         try:
@@ -53,12 +58,24 @@ class AccountRecoveryAPIView(APIView):
             email_service.verify_code(purpose, **serializer.validated_data)  # 검증 코드 호출
 
             # 4) 계정 복구
-            user = recover_account(**serializer.validated_data)
+            recover_account(**serializer.validated_data)
 
             # 5) 성공 응답
             return Response({"detail": "계정이 복구되었습니다. 이제 로그인할 수 있습니다."}, status=status.HTTP_200_OK)
 
-        # 6) 실패 응답(오류 제어는 나중에)
+        # 6) 실패 응답
+        # 6-1) 이메일 발송 시스템에 문제가 발생하였습니다.
+        except EmailSendingFailedError as e:
+            return Response({"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+        # 6-2) 이메일 인증 코드가 일치하지 않습니다.
+        except EmailVerificationCodeFailedError as e:
+            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+        # 6-3) 해당 이메일로 탈퇴 요청이 존재하지 않습니다.
+        except Withdrawals.DoesNotExist as e:
+            return Response({"detail": str(e)}, status=status.HTTP_404_NOT_FOUND)
+
         except Exception as e:
             return Response(
                 {"detail": f"알 수 없는 오류가 발생했습니다. {str(e)}."}, status=status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #64 
- 작업 요약: 회원 탈퇴를 복구하는 API 구현(이메일로 받은 코드를 유저가 입력하면 해당 코드가 유효한지 검증, 해당 유저의 탈퇴를 번복하고 계정을 활성화).

## 📄 상세 내용
- [x] serializer: 복구 코드 입력 검증.
- [x] service: 이메일/인증 코드 검증, 복구 성공 시 계정 활성화 및 탈퇴 요청 삭제(비즈니스 로직).
- [x] view: 탈퇴 계정 복구 요청. 이메일/인증 코드 검증, 복구 성공 시 계정 활성화 및 탈퇴 요청 삭제(HTTP 처리).
- [x] urls 추가, 테스트 코드 작성 및 인증/양식 오류 수정.
- [x] 파일명을 더욱 직관적으로 변경.

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다(버그 수정/기능에 대한 테스트).
