### PR TITLE
✨ feat: 사용자 정보 수정 및 삭제 기능 구현

### DIFF
--- a/apps/users/serializers/admin_serializers.py
+++ b/apps/users/serializers/admin_serializers.py
@@ -152,3 +152,26 @@ class UserAdminDetailSerializer(serializers.ModelSerializer[User]):
         if hasattr(obj, "withdrawals") and obj.withdrawals:
             return "탈퇴진행중"
         return "활성화" if obj.is_active else "비활성화"
+
+
+# 회원 정보 수정 시리얼라이저
+class UserAdminUpdateSerializer(serializers.ModelSerializer[User]):
+    status = serializers.ChoiceField(choices=[("active", "활성화"), ("inactive", "비활성화")], write_only=True)
+
+    class Meta:
+        model = User
+        fields = [
+            "name",
+            "gender",
+            "nickname",
+            "phone_number",
+            "status",
+            "profile_img_url",
+        ]
+
+    def update(self, instance: User, validated_data: Dict[str, Any]) -> User:
+        if "status" in validated_data:
+            status = validated_data.get("status")
+            instance.is_active = status == "active"
+
+        return super().update(instance, validated_data)

--- a/apps/users/tests/test_admin.py
+++ b/apps/users/tests/test_admin.py
@@ -150,7 +150,7 @@ class UserAdminAPITest(APITestCase):
         self.assertEqual(self.active_user.nickname, "changed_us")
         self.assertFalse(self.active_user.is_active)
 
-    def test_user_update_fail_as_staff(self) -> None:
+    def test_user_update_success_as_staff(self) -> None:
         """스태프 권한을 가진 유저가 다른 유저의 정보 수정 테스트"""
         self.client.force_authenticate(user=self.staff_user)
 

--- a/apps/users/tests/test_admin.py
+++ b/apps/users/tests/test_admin.py
@@ -134,3 +134,64 @@ class UserAdminAPITest(APITestCase):
         # 정렬 기능 테스트
         response = self.client.get(self.list_url, {"ordering": "-created_at"})
         self.assertEqual(response.data["results"][0]["email"], self.withdrawn_user.email)
+
+    # 회원 정보 수정 API 테스트
+    def test_user_update_success_as_admin(self) -> None:
+        """관리자 권한을 가진 유저가 다른 유저의 정보 수정 테스트"""
+        self.client.force_authenticate(user=self.superuser)
+
+        detail_url = reverse("admin_user:users-detail", kwargs={"uuid": self.active_user.uuid})
+        data = {"nickname": "changed_us", "status": "inactive"}
+        response = self.client.patch(detail_url, data=data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.active_user.refresh_from_db()
+        self.assertEqual(self.active_user.nickname, "changed_us")
+        self.assertFalse(self.active_user.is_active)
+
+    def test_user_update_fail_as_staff(self) -> None:
+        """스태프 권한을 가진 유저가 다른 유저의 정보 수정 테스트"""
+        self.client.force_authenticate(user=self.staff_user)
+
+        detail_url = reverse("admin_user:users-detail", kwargs={"uuid": self.active_user.uuid})
+        data = {"nickname": "changed_sf"}
+        response = self.client.patch(detail_url, data=data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.active_user.refresh_from_db()
+        self.assertEqual(self.active_user.nickname, "changed_sf")
+
+    def test_user_update_fail_for_general_staff(self) -> None:
+        """권한이 없는 유저가 다른 유저 정보 수정시 403 에러 발생 여부 테스트"""
+        self.client.force_authenticate(user=self.active_user)
+        detail_url = reverse("admin_user:users-detail", kwargs={"uuid": self.active_user.uuid})
+        data = {"nickname": "hacked"}
+
+        responses = self.client.patch(detail_url, data=data, format="json")
+        self.assertEqual(responses.status_code, status.HTTP_403_FORBIDDEN)
+
+    # 회원 정보 삭제 테스트
+    def test_delete_user_success_as_superuser(self) -> None:
+        """관리자(superuser)권한 유저가 다른 유저 정보를 삭제하는 테스트"""
+        self.client.force_authenticate(user=self.superuser)
+
+        target_user_uuid = self.active_user.uuid
+        detail_url = reverse("admin_user:users-detail", kwargs={"uuid": target_user_uuid})
+
+        responses = self.client.delete(detail_url)
+
+        self.assertEqual(responses.status_code, status.HTTP_204_NO_CONTENT)
+
+        with self.assertRaises(user_model.DoesNotExist):
+            user_model.objects.get(uuid=target_user_uuid)
+
+    def test_delete_user_fail_as_staff(self) -> None:
+        """스태프(staff)권한 유저가 다른 유저 정보를 삭제하는 테스트"""
+        self.client.force_authenticate(user=self.staff_user)
+        detail_url = reverse("admin_user:users-detail", kwargs={"uuid": self.active_user.uuid})
+
+        responses = self.client.delete(detail_url)
+
+        self.assertEqual(responses.status_code, status.HTTP_403_FORBIDDEN)

--- a/apps/users/urls/admin_urls.py
+++ b/apps/users/urls/admin_urls.py
@@ -6,7 +6,7 @@ from apps.users.views.admin_views import UserAdminViewSet, UserPermissionUpdateA
 app_name = "admin_user"
 
 router = DefaultRouter()
-router.register("users", UserAdminViewSet, basename="users")
+router.register("", UserAdminViewSet, basename="users")
 
 urlpatterns: list[URLPattern | URLResolver] = [
     path("users/<uuid:user_uuid>/permission", UserPermissionUpdateAPIView.as_view(), name="user_permissions"),

--- a/apps/users/views/admin_views.py
+++ b/apps/users/views/admin_views.py
@@ -5,7 +5,7 @@ from django.shortcuts import get_object_or_404
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, serializers, status, viewsets
 from rest_framework.pagination import PageNumberPagination
-from rest_framework.permissions import IsAdminUser
+from rest_framework.permissions import BasePermission, IsAdminUser
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -16,6 +16,7 @@ from apps.users.permissions import IsSuperUser
 from apps.users.serializers.admin_serializers import (
     UserAdminDetailSerializer,
     UserAdminListSerializer,
+    UserAdminUpdateSerializer,
     UserPermissionResponseSerializer,
     UserPermissionUpdateSerializer,
 )
@@ -52,13 +53,15 @@ class UserAdminPagination(PageNumberPagination):
     max_page_size = 50
 
 
-class UserAdminViewSet(viewsets.ReadOnlyModelViewSet[User]):
+class UserAdminViewSet(viewsets.ModelViewSet[User]):
     """
-    관리자용 회원 목록 조회 및 회원 정보 상세 조회 API
+    관리자용 회원 CRUD API
+    목록 조회 / 정보 상세 조회 (GET)
+    회원 정보 수정 (PATCH)
+    회원 정보 삭제 (DELETE)
     """
 
     queryset = User.objects.select_related("withdrawals").all().order_by("uuid")
-    permission_classes = [IsAdminUser]
     lookup_field = "uuid"
 
     # 페이지네이션, 필터링, 검색, 정렬 기능 구현
@@ -72,8 +75,20 @@ class UserAdminViewSet(viewsets.ReadOnlyModelViewSet[User]):
     # 정렬 필드 지정
     ordering_fields = ["uuid", "created_at", "name", "email"]
 
+    def get_permissions(self) -> list[BasePermission]:
+        """요청에 따라 다른 권한을 적용합니다."""
+        if self.action == "destroy":
+            # 회원 정보 삭제는 관리자(superuser)만 가능하도록 권한 설정
+            return [IsSuperUser()]
+        # 그 외 조회, 상세조회, 수정은 스태프 권한 이상 가능하도록 설정
+        return [IsAdminUser()]
+
     # 요청에 따라 목록 조회 or 정보 상세 조회 시리얼라이저 반환
-    def get_serializer_class(self) -> Type[Union[UserAdminDetailSerializer, UserAdminListSerializer]]:
+    def get_serializer_class(
+        self,
+    ) -> Type[Union[UserAdminDetailSerializer, UserAdminListSerializer, UserAdminUpdateSerializer]]:
+        if self.action in ["update", "partial_update"]:
+            return UserAdminUpdateSerializer
         if self.action == "retrieve":
             return UserAdminDetailSerializer
 


### PR DESCRIPTION
관리자 페이지에서 사용자 정보를 수정하고 삭제하는 기능 구현, 정의서에 따라 정보 삭제는 관리자(superuser)만 가능하게 views 권한 관련 코드 리팩토링

## ✅ PR 요약
- 관련 이슈 번호: #105
- 작업 요약: 관리자 페이지 회원 정보 수정 및 삭제 API 구현

## 📄 상세 내용
- [x] 관리자 페이지 회원 정보 수정 serializer, view 작성
- [x] 관리자 페이지 회원 정보 삭제 serializer, view 작성
- [x] 요청에 따라 다른 권한 적용을 위한 view 리팩토링 (회원 정보 삭제는 최고관리자, superuser 만 사용 가능하게 분리)

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
