### PR TITLE
✨ feat: 스터디 구인 공고 삭제하기 api 추가

### DIFF
--- a/apps/recruitments/services/recruitments_services.py
+++ b/apps/recruitments/services/recruitments_services.py
@@ -15,3 +15,7 @@ def get_recruitment_detail(recruitment_uuid: UUID) -> Recruitment:
         return recruitment
     except Recruitment.DoesNotExist:
         raise NotFound("해당 공고를 찾을 수 없음.")
+
+
+def delete_recruitment(recruitment: Recruitment) -> None:
+    recruitment.delete()

--- a/apps/recruitments/services/recruitments_services.py
+++ b/apps/recruitments/services/recruitments_services.py
@@ -15,7 +15,3 @@ def get_recruitment_detail(recruitment_uuid: UUID) -> Recruitment:
         return recruitment
     except Recruitment.DoesNotExist:
         raise NotFound("해당 공고를 찾을 수 없음.")
-
-
-def delete_recruitment(recruitment: Recruitment) -> None:
-    recruitment.delete()

--- a/apps/recruitments/tests/test_recruitments.py
+++ b/apps/recruitments/tests/test_recruitments.py
@@ -186,3 +186,26 @@ class RecruitmentDetailViewTest(APITransactionTestCase):
         update_data = {"title": "잘못된 사용자"}
         response = self.client.patch(url, data=update_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_delete_recruitment_by_author_success(self) -> None:
+        self.client.force_authenticate(user=self.author)
+        url = reverse("recruitment-detail", kwargs={"recruitment_uuid": self.recruitment.uuid})
+
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Recruitment.objects.filter(uuid=self.recruitment.uuid).exists())
+
+    def test_delete_recruitment_permission_denied(self) -> None:
+        self.client.force_authenticate(user=self.other_user)
+        url = reverse("recruitment-detail", kwargs={"recruitment_uuid": self.recruitment.uuid})
+
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertTrue(Recruitment.objects.filter(uuid=self.recruitment.uuid).exists())
+
+    def test_delete_recruitment_unauthenticated(self) -> None:
+        url = reverse("recruitment-detail", kwargs={"recruitment_uuid": self.recruitment.uuid})
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertTrue(Recruitment.objects.filter(uuid=self.recruitment.uuid).exists())

--- a/apps/recruitments/tests/test_recruitments.py
+++ b/apps/recruitments/tests/test_recruitments.py
@@ -105,11 +105,8 @@ class RecruitmentDetailViewTest(APITransactionTestCase):
     def test_get_recruitment_detail_success(self) -> None:
         # GIVEN
         url = reverse("recruitment-detail", kwargs={"recruitment_uuid": self.recruitment.uuid})
-        context = {"request": self.client.request().wsgi_request}
-        serializer = RecruitmentDetailSerializer(
-            instance=self.recruitment, context={"requests": self.client.request().wsgi_request}
-        )
-        expected_data = RecruitmentDetailSerializer(instance=self.recruitment).data
+        request = self.client.request().wsgi_request
+        expected_data = RecruitmentDetailSerializer(instance=self.recruitment, context={"requests": request}).data
         # WHEN
         response = self.client.get(url)
         # THEN
@@ -186,6 +183,12 @@ class RecruitmentDetailViewTest(APITransactionTestCase):
         update_data = {"title": "잘못된 사용자"}
         response = self.client.patch(url, data=update_data, format="json")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_update_recruitment_unauthenticated(self) -> None:
+        url = reverse("recruitment-detail", kwargs={"recruitment_uuid": self.recruitment.uuid})
+        update_data = {"title": "비로그인 수정 시도"}
+        response = self.client.patch(url, data=update_data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_delete_recruitment_by_author_success(self) -> None:
         self.client.force_authenticate(user=self.author)

--- a/apps/recruitments/views/recruitment_detail_views.py
+++ b/apps/recruitments/views/recruitment_detail_views.py
@@ -108,10 +108,10 @@ class RecruitmentDetailView(APIView):
         if not request.user.is_authenticated:
             return Response({"error": "인증이 필요합니다."}, status=status.HTTP_401_UNAUTHORIZED)
 
-        recruitment_to_delete = self._get_object(recruitment_uuid)
+        recruitment = self._get_object(recruitment_uuid)
 
-        if request.user != recruitment_to_delete.author:
+        if request.user != recruitment.author:
             return Response({"이 공고를 삭제할 권한이 없습니다."}, status=status.HTTP_403_FORBIDDEN)
 
-        recruitment_to_delete.delete()
+        recruitment.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apps/recruitments/views/recruitment_detail_views.py
+++ b/apps/recruitments/views/recruitment_detail_views.py
@@ -18,7 +18,7 @@ from ..services.recruitments_services import get_recruitment_detail
 
 
 class RecruitmentDetailView(APIView):
-    permission_classes = [AllowAny]  # 그냥 조회는 누구나 가능
+    permission_classes = [AllowAny]  # 그냥 조회는 누구나 가능합니다
     authentication_classes = ()
     parser_classes = [JSONParser, MultiPartParser]
 
@@ -42,7 +42,7 @@ class RecruitmentDetailView(APIView):
             OpenApiParameter(
                 name="recruitment_uuid",
                 type=UUID,
-                location=OpenApiParameter.PATH,  # type: ignore
+                location=OpenApiParameter.PATH,
                 description="조회할 공고의 고유 UUID",
             ),
         ],
@@ -64,7 +64,7 @@ class RecruitmentDetailView(APIView):
             OpenApiParameter(
                 name="recruitment_uuid",
                 type=UUID,
-                location=OpenApiParameter.PATH,  # type: ignore
+                location=OpenApiParameter.PATH,
                 description="수정할 공고의 고유 UUID",
             ),
         ],
@@ -99,7 +99,7 @@ class RecruitmentDetailView(APIView):
             OpenApiParameter(
                 name="recruitment_uuid",
                 type=UUID,
-                location=OpenApiParameter.PATH,  # type: ignore
+                location=OpenApiParameter.PATH,
                 description="삭제할 공고의 고유 UUID",
             ),
         ],

--- a/apps/recruitments/views/recruitment_detail_views.py
+++ b/apps/recruitments/views/recruitment_detail_views.py
@@ -14,7 +14,7 @@ from ..serializers.recruitments_serializers import (
     RecruitmentDetailSerializer,
     RecruitmentUpdateSerializer,
 )
-from ..services.recruitments_services import get_recruitment_detail
+from ..services.recruitments_services import delete_recruitment, get_recruitment_detail
 
 
 class RecruitmentDetailView(APIView):
@@ -79,3 +79,34 @@ class RecruitmentDetailView(APIView):
         updated_instance = serializer.save()
 
         return Response(RecruitmentDetailSerializer(updated_instance).data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        summary="스터디 구인 공고 삭제",
+        description="recruitment_uuid에 해당하는 구인공고 삭제, 작성자만 삭제 가능",
+        responses={
+            status.HTTP_204_NO_CONTENT: OpenApiResponse(description="삭제 성공. 응답 본문 없음."),
+            status.HTTP_401_UNAUTHORIZED: OpenApiResponse(description="인증이 필요합니다."),
+            status.HTTP_403_FORBIDDEN: OpenApiResponse(description="삭제 권한이 없습니다."),
+            status.HTTP_404_NOT_FOUND: OpenApiResponse(description="해당 공고를 찾을 수 없습니다."),
+        },
+        parameters=[
+            OpenApiParameter(
+                name="recruitment_uuid",
+                type=UUID,
+                location=OpenApiParameter.PATH,
+                description="삭제할 공고의 고유 UUID",
+            ),
+        ],
+    )
+    def delete(self, request: Request, recruitment_uuid: UUID) -> Response:
+        recruitment_to_delete = self.get_object(recruitment_uuid=recruitment_uuid)
+
+        if not request.user.is_authenticated:
+            return Response({"error": "인증이 필요합니다."}, status=status.HTTP_401_UNAUTHORIZED)
+
+        if request.user != recruitment_to_delete.author:
+            return Response({"이 공고를 삭제할 권한이 없습니다."}, status=status.HTTP_403_FORBIDDEN)
+
+        delete_recruitment(recruitment=recruitment_to_delete)
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apps/recruitments/views/recruitment_detail_views.py
+++ b/apps/recruitments/views/recruitment_detail_views.py
@@ -14,11 +14,11 @@ from ..serializers.recruitments_serializers import (
     RecruitmentDetailSerializer,
     RecruitmentUpdateSerializer,
 )
-from ..services.recruitments_services import delete_recruitment, get_recruitment_detail
+from ..services.recruitments_services import get_recruitment_detail
 
 
 class RecruitmentDetailView(APIView):
-    permission_classes = [AllowAny]
+    permission_classes = [AllowAny]  # 그냥 조회는 누구나 가능
     authentication_classes = ()
     parser_classes = [JSONParser, MultiPartParser]
 
@@ -69,6 +69,9 @@ class RecruitmentDetailView(APIView):
         ],
     )
     def patch(self, request: Request, recruitment_uuid: UUID) -> Response:
+        if not request.user.is_authenticated:
+            return Response({"error": "인증이 필요합니다."}, status=status.HTTP_401_UNAUTHORIZED)
+
         recruitment_to_update = self.get_object(recruitment_uuid=recruitment_uuid)
 
         if request.user != recruitment_to_update.author:
@@ -78,7 +81,9 @@ class RecruitmentDetailView(APIView):
         serializer.is_valid(raise_exception=True)
         updated_instance = serializer.save()
 
-        return Response(RecruitmentDetailSerializer(updated_instance).data, status=status.HTTP_200_OK)
+        return Response(
+            RecruitmentDetailSerializer(updated_instance, context={"request": request}).data, status=status.HTTP_200_OK
+        )
 
     @extend_schema(
         summary="스터디 구인 공고 삭제",
@@ -99,7 +104,7 @@ class RecruitmentDetailView(APIView):
         ],
     )
     def delete(self, request: Request, recruitment_uuid: UUID) -> Response:
-        recruitment_to_delete = self.get_object(recruitment_uuid=recruitment_uuid)
+        recruitment_to_delete = self.get_object(recruitment_uuid)
 
         if not request.user.is_authenticated:
             return Response({"error": "인증이 필요합니다."}, status=status.HTTP_401_UNAUTHORIZED)
@@ -107,6 +112,5 @@ class RecruitmentDetailView(APIView):
         if request.user != recruitment_to_delete.author:
             return Response({"이 공고를 삭제할 권한이 없습니다."}, status=status.HTTP_403_FORBIDDEN)
 
-        delete_recruitment(recruitment=recruitment_to_delete)
-
+        recruitment_to_delete.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apps/recruitments/views/recruitment_detail_views.py
+++ b/apps/recruitments/views/recruitment_detail_views.py
@@ -22,7 +22,8 @@ class RecruitmentDetailView(APIView):
     authentication_classes = ()
     parser_classes = [JSONParser, MultiPartParser]
 
-    def get_object(self, recruitment_uuid: UUID) -> Recruitment:
+    @staticmethod
+    def _get_object(recruitment_uuid: UUID) -> Recruitment:
         try:
             return Recruitment.objects.get(uuid=recruitment_uuid)
         except Recruitment.DoesNotExist:
@@ -41,7 +42,7 @@ class RecruitmentDetailView(APIView):
             OpenApiParameter(
                 name="recruitment_uuid",
                 type=UUID,
-                location=OpenApiParameter.PATH,
+                location=OpenApiParameter.PATH, #type: ignore
                 description="조회할 공고의 고유 UUID",
             ),
         ],
@@ -63,7 +64,7 @@ class RecruitmentDetailView(APIView):
             OpenApiParameter(
                 name="recruitment_uuid",
                 type=UUID,
-                location=OpenApiParameter.PATH,
+                location=OpenApiParameter.PATH, # type: ignore
                 description="수정할 공고의 고유 UUID",
             ),
         ],
@@ -72,7 +73,7 @@ class RecruitmentDetailView(APIView):
         if not request.user.is_authenticated:
             return Response({"error": "인증이 필요합니다."}, status=status.HTTP_401_UNAUTHORIZED)
 
-        recruitment_to_update = self.get_object(recruitment_uuid=recruitment_uuid)
+        recruitment_to_update = self._get_object(recruitment_uuid=recruitment_uuid)
 
         if request.user != recruitment_to_update.author:
             return Response({"error": "이 공고를 수정할 권한이 없습니다."}, status=status.HTTP_403_FORBIDDEN)
@@ -98,16 +99,16 @@ class RecruitmentDetailView(APIView):
             OpenApiParameter(
                 name="recruitment_uuid",
                 type=UUID,
-                location=OpenApiParameter.PATH,
+                location=OpenApiParameter.PATH, # type: ignore
                 description="삭제할 공고의 고유 UUID",
             ),
         ],
     )
     def delete(self, request: Request, recruitment_uuid: UUID) -> Response:
-        recruitment_to_delete = self.get_object(recruitment_uuid)
-
         if not request.user.is_authenticated:
             return Response({"error": "인증이 필요합니다."}, status=status.HTTP_401_UNAUTHORIZED)
+
+        recruitment_to_delete = self._get_object(recruitment_uuid)
 
         if request.user != recruitment_to_delete.author:
             return Response({"이 공고를 삭제할 권한이 없습니다."}, status=status.HTTP_403_FORBIDDEN)

--- a/apps/recruitments/views/recruitment_detail_views.py
+++ b/apps/recruitments/views/recruitment_detail_views.py
@@ -42,7 +42,7 @@ class RecruitmentDetailView(APIView):
             OpenApiParameter(
                 name="recruitment_uuid",
                 type=UUID,
-                location=OpenApiParameter.PATH, #type: ignore
+                location=OpenApiParameter.PATH,  # type: ignore
                 description="조회할 공고의 고유 UUID",
             ),
         ],
@@ -64,7 +64,7 @@ class RecruitmentDetailView(APIView):
             OpenApiParameter(
                 name="recruitment_uuid",
                 type=UUID,
-                location=OpenApiParameter.PATH, # type: ignore
+                location=OpenApiParameter.PATH,  # type: ignore
                 description="수정할 공고의 고유 UUID",
             ),
         ],
@@ -99,7 +99,7 @@ class RecruitmentDetailView(APIView):
             OpenApiParameter(
                 name="recruitment_uuid",
                 type=UUID,
-                location=OpenApiParameter.PATH, # type: ignore
+                location=OpenApiParameter.PATH,  # type: ignore
                 description="삭제할 공고의 고유 UUID",
             ),
         ],


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #143 
- 작업 요약: 어떤 작업을 했는지 간단하게 적어주세요.

## 📄 상세 내용
- [ ] DELETE 메서드를 추가하여 삭제 API 엔드포인트를 구현
- [ ] 삭제 성공 시, 별도의 응답 본문 없이 204 No Content 상태 코드를 반환
- [ ] 주요 변경 사항 3

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
버튼 클릭 시 공고가 즉시 삭제되며 되돌릴 수 없음을 안내하는 팝업 메시지를 노출해야 합니다.
ㄴ 해당 사항은 프론트의 역할이 맞을까요?

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
