### PR TITLE
관리자 강의 목록 API 구현

### DIFF
--- a/apps/lectures/permissions.py
+++ b/apps/lectures/permissions.py
@@ -1,0 +1,11 @@
+from rest_framework.permissions import BasePermission
+from rest_framework.request import Request
+from rest_framework.views import APIView
+
+
+class AdminOnly(BasePermission):
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        user = request.user
+        if not getattr(user, "is_authenticated", False):
+            return False
+        return bool(getattr(user, "is_staff", False) or getattr(user, "is_superuser", False))

--- a/apps/lectures/serializers/admin_lecture_serializers.py
+++ b/apps/lectures/serializers/admin_lecture_serializers.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from rest_framework import serializers
+
+from apps.lectures.models.crawled_lectures import Lecture
+
+
+class AdminLectureListSerializer(serializers.ModelSerializer[Lecture]):
+    lecture_id = serializers.IntegerField(source="id", read_only=True)
+
+    class Meta:
+        model = Lecture
+        fields = (
+            "lecture_id",
+            "title",
+            "instructor",
+            "thumbnail_img_url",
+            "platform",
+            "url_link",
+            "created_at",
+            "updated_at",
+        )
+        read_only_fields = fields

--- a/apps/lectures/serializers/admin_lecture_serializers.py
+++ b/apps/lectures/serializers/admin_lecture_serializers.py
@@ -6,12 +6,10 @@ from apps.lectures.models.crawled_lectures import Lecture
 
 
 class AdminLectureListSerializer(serializers.ModelSerializer[Lecture]):
-    lecture_uuid = serializers.UUIDField(source="uuid", read_only=True)
-
     class Meta:
         model = Lecture
         fields = (
-            "lecture_uuid",
+            "id",
             "title",
             "instructor",
             "thumbnail_img_url",

--- a/apps/lectures/serializers/admin_lecture_serializers.py
+++ b/apps/lectures/serializers/admin_lecture_serializers.py
@@ -6,12 +6,12 @@ from apps.lectures.models.crawled_lectures import Lecture
 
 
 class AdminLectureListSerializer(serializers.ModelSerializer[Lecture]):
-    lecture_id = serializers.IntegerField(source="id", read_only=True)
+    lecture_uuid = serializers.UUIDField(source="uuid", read_only=True)
 
     class Meta:
         model = Lecture
         fields = (
-            "lecture_id",
+            "lecture_uuid",
             "title",
             "instructor",
             "thumbnail_img_url",

--- a/apps/lectures/tests/test_admin_lectures.py
+++ b/apps/lectures/tests/test_admin_lectures.py
@@ -1,3 +1,6 @@
+from typing import ClassVar
+
+from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -6,9 +9,12 @@ from apps.users.models.user import User
 
 
 class TestAdminLectureList(APITestCase):
-    def setUp(self) -> None:
-        # 일반 유저
-        self.user = User.objects.create_user(
+    user: ClassVar[User]
+    admin: ClassVar[User]
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.user = User.objects.create_user(
             email="user@test.com",
             password="pass1234",
             name="유저",
@@ -17,8 +23,7 @@ class TestAdminLectureList(APITestCase):
             gender="M",
             birthday="2000-01-01",
         )
-        # 관리자 유저
-        self.admin = User.objects.create_user(
+        cls.admin = User.objects.create_user(
             email="admin@test.com",
             password="pass1234",
             name="관리자",
@@ -28,19 +33,6 @@ class TestAdminLectureList(APITestCase):
             birthday="1999-12-31",
             is_staff=True,
         )
-        self.url = "/api/v1/lectures/admin/lectures"
-
-    def test_auth_required(self) -> None:
-        res = self.client.get(self.url)
-        self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
-
-    def test_admin_only(self) -> None:
-        self.client.force_authenticate(user=self.user)
-        res = self.client.get(self.url)
-        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
-
-    def test_list_ok(self) -> None:
-        # 데이터
         Lecture.objects.create(
             title="Github Mastery",
             instructor="효종 조교",
@@ -66,15 +58,27 @@ class TestAdminLectureList(APITestCase):
             thumbnail_img_url="drf.png",
         )
 
-        self.client.force_authenticate(user=self.admin)
-        res = self.client.get(self.url, data={"limit": 1, "offset": 0})
+    def test_auth_required(self) -> None:
+        url = reverse("lectures-admin:admin-lecture-list")
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_admin_only(self) -> None:
+        url = reverse("lectures-admin:admin-lecture-list")
+        self.client.force_authenticate(user=type(self).user)
+        res = self.client.get(url)
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_list_ok(self) -> None:
+        url = reverse("lectures-admin:admin-lecture-list")
+        self.client.force_authenticate(user=type(self).admin)
+        res = self.client.get(url, data={"limit": 1, "offset": 0})
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertIn("count", res.data)
         self.assertIn("results", res.data)
         self.assertEqual(len(res.data["results"]), 1)
 
-        # 검색
-        res_search = self.client.get(self.url, data={"search": "django"})
+        res_search = self.client.get(url, data={"search": "django"})
         self.assertEqual(res_search.status_code, status.HTTP_200_OK)
         titles = [item["title"] for item in res_search.data["results"]]
         self.assertTrue(any("Django" in t for t in titles))

--- a/apps/lectures/tests/test_admin_lectures.py
+++ b/apps/lectures/tests/test_admin_lectures.py
@@ -59,18 +59,18 @@ class TestAdminLectureList(APITestCase):
         )
 
     def test_auth_required(self) -> None:
-        url = reverse("lectures-admin:admin-lecture-list")
+        url = reverse("admin-lecture-list")
         res = self.client.get(url)
         self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_admin_only(self) -> None:
-        url = reverse("lectures-admin:admin-lecture-list")
+        url = reverse("admin-lecture-list")
         self.client.force_authenticate(user=type(self).user)
         res = self.client.get(url)
         self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_list_ok(self) -> None:
-        url = reverse("lectures-admin:admin-lecture-list")
+        url = reverse("admin-lecture-list")
         self.client.force_authenticate(user=type(self).admin)
         res = self.client.get(url, data={"limit": 1, "offset": 0})
         self.assertEqual(res.status_code, status.HTTP_200_OK)

--- a/apps/lectures/tests/test_admin_lectures.py
+++ b/apps/lectures/tests/test_admin_lectures.py
@@ -1,0 +1,80 @@
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.lectures.models.crawled_lectures import Lecture
+from apps.users.models.user import User
+
+
+class TestAdminLectureList(APITestCase):
+    def setUp(self) -> None:
+        # 일반 유저
+        self.user = User.objects.create_user(
+            email="user@test.com",
+            password="pass1234",
+            name="유저",
+            nickname="user",
+            phone_number="01000000000",
+            gender="M",
+            birthday="2000-01-01",
+        )
+        # 관리자 유저
+        self.admin = User.objects.create_user(
+            email="admin@test.com",
+            password="pass1234",
+            name="관리자",
+            nickname="admin",
+            phone_number="01011112222",
+            gender="M",
+            birthday="1999-12-31",
+            is_staff=True,
+        )
+        self.url = "/api/v1/lectures/admin/lectures"
+
+    def test_auth_required(self) -> None:
+        res = self.client.get(self.url)
+        self.assertEqual(res.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_admin_only(self) -> None:
+        self.client.force_authenticate(user=self.user)
+        res = self.client.get(self.url)
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_list_ok(self) -> None:
+        # 데이터
+        Lecture.objects.create(
+            title="Github Mastery",
+            instructor="효종 조교",
+            duration=60,
+            difficulty="normal",
+            description="깃허브",
+            platform="Inflearn",
+            original_price=10000,
+            discount_price=5000,
+            url_link="https://inflearn.com/github",
+            thumbnail_img_url="github.png",
+        )
+        Lecture.objects.create(
+            title="Django REST Framework",
+            instructor="머용코치",
+            duration=120,
+            difficulty="normal",
+            description="DRF",
+            platform="Inflearn",
+            original_price=20000,
+            discount_price=15000,
+            url_link="https://inflearn.com/django-rest",
+            thumbnail_img_url="drf.png",
+        )
+
+        self.client.force_authenticate(user=self.admin)
+        res = self.client.get(self.url, data={"limit": 1, "offset": 0})
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertIn("count", res.data)
+        self.assertIn("results", res.data)
+        self.assertEqual(len(res.data["results"]), 1)
+
+        # 검색
+        res_search = self.client.get(self.url, data={"search": "django"})
+        self.assertEqual(res_search.status_code, status.HTTP_200_OK)
+        titles = [item["title"] for item in res_search.data["results"]]
+        self.assertTrue(any("Django" in t for t in titles))

--- a/apps/lectures/urls/__init__.py
+++ b/apps/lectures/urls/__init__.py
@@ -1,5 +1,9 @@
-from django.urls import URLPattern, URLResolver
+from django.urls import URLPattern, URLResolver, include, path
 
+from apps.lectures.urls.admin_urls import urlpatterns as admin_urls
 from apps.lectures.urls.bookmarks_urls import urlpatterns as bookmark_urls
 
-urlpatterns: list[URLPattern | URLResolver] = [*bookmark_urls]
+urlpatterns: list[URLPattern | URLResolver] = [
+    *bookmark_urls,
+    path("/admin/lectures", include((admin_urls, "admin-lectures"), namespace="admin-lectures")),
+]

--- a/apps/lectures/urls/__init__.py
+++ b/apps/lectures/urls/__init__.py
@@ -5,5 +5,4 @@ from apps.lectures.urls.bookmarks_urls import urlpatterns as bookmark_urls
 
 urlpatterns: list[URLPattern | URLResolver] = [
     *bookmark_urls,
-    path("/admin/lectures", include((admin_urls, "lectures-admin"), namespace="lectures-admin")),
 ]

--- a/apps/lectures/urls/__init__.py
+++ b/apps/lectures/urls/__init__.py
@@ -5,5 +5,5 @@ from apps.lectures.urls.bookmarks_urls import urlpatterns as bookmark_urls
 
 urlpatterns: list[URLPattern | URLResolver] = [
     *bookmark_urls,
-    path("/admin/lectures", include((admin_urls, "admin-lectures"), namespace="admin-lectures")),
+    path("/admin/lectures", include((admin_urls, "lectures-admin"), namespace="lectures-admin")),
 ]

--- a/apps/lectures/urls/admin_urls.py
+++ b/apps/lectures/urls/admin_urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from apps.lectures.views.admin_lecture_views import AdminLectureListView
+
+urlpatterns = [
+    path("", AdminLectureListView.as_view(), name="admin-lecture-list"),
+]

--- a/apps/lectures/views/admin_lecture_views.py
+++ b/apps/lectures/views/admin_lecture_views.py
@@ -7,23 +7,13 @@ from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework import permissions
 from rest_framework.generics import ListAPIView
 from rest_framework.pagination import LimitOffsetPagination
-from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.views import APIView
 
 from apps.lectures.models.crawled_lectures import Lecture
+from apps.lectures.permissions import AdminOnly
 from apps.lectures.serializers.admin_lecture_serializers import (
     AdminLectureListSerializer,
 )
-
-
-class AdminOnly(permissions.BasePermission):
-
-    def has_permission(self, request: Request, view: APIView) -> bool:
-        user = request.user
-        if not getattr(user, "is_authenticated", False):
-            return False
-        return bool(getattr(user, "is_staff", False) or getattr(user, "is_superuser", False))
 
 
 class AdminLectureLimitOffsetPagination(LimitOffsetPagination):
@@ -51,9 +41,6 @@ class AdminLectureListView(ListAPIView[Lecture]):
         ],
         responses={200: AdminLectureListSerializer(many=True)},  # pagination wrapper: {"count", "results"}
     )
-    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
-        return super().get(request, *args, **kwargs)
-
     def get_queryset(self) -> QuerySet[Lecture]:
         qs: QuerySet[Lecture] = Lecture.objects.all().order_by("-created_at", "-pk")
         keyword = self.request.query_params.get("search")

--- a/apps/lectures/views/admin_lecture_views.py
+++ b/apps/lectures/views/admin_lecture_views.py
@@ -20,12 +20,8 @@ class AdminLectureLimitOffsetPagination(LimitOffsetPagination):
     default_limit = 20
     max_limit = 100
 
-    def get_paginated_response(self, data: list[dict[str, Any]]) -> Response:
-        return Response({"count": self.count, "results": data})
-
 
 class AdminLectureListView(ListAPIView[Lecture]):
-
     permission_classes = [permissions.IsAuthenticated, AdminOnly]
     serializer_class = AdminLectureListSerializer
     pagination_class = AdminLectureLimitOffsetPagination

--- a/apps/lectures/views/admin_lecture_views.py
+++ b/apps/lectures/views/admin_lecture_views.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Any
+
+from django.db.models import Q, QuerySet
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+from rest_framework import permissions
+from rest_framework.generics import ListAPIView
+from rest_framework.pagination import LimitOffsetPagination
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.lectures.models.crawled_lectures import Lecture
+from apps.lectures.serializers.admin_lecture_serializers import (
+    AdminLectureListSerializer,
+)
+
+
+class AdminOnly(permissions.BasePermission):
+
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        user = request.user
+        if not getattr(user, "is_authenticated", False):
+            return False
+        return bool(getattr(user, "is_staff", False) or getattr(user, "is_superuser", False))
+
+
+class AdminLectureLimitOffsetPagination(LimitOffsetPagination):
+    default_limit = 20
+    max_limit = 100
+
+    def get_paginated_response(self, data: list[dict[str, Any]]) -> Response:
+        return Response({"count": self.count, "results": data})
+
+
+class AdminLectureListView(ListAPIView[Lecture]):
+
+    permission_classes = [permissions.IsAuthenticated, AdminOnly]
+    serializer_class = AdminLectureListSerializer
+    pagination_class = AdminLectureLimitOffsetPagination
+
+    @extend_schema(
+        tags=["관리자"],
+        summary="강의 관리 목록 조회",
+        description="관리자 권한으로 강의의 목록을 조회한다.",
+        parameters=[
+            OpenApiParameter(name="limit", type=int, location="query", required=False, description="데이터 수"),
+            OpenApiParameter(name="offset", type=int, location="query", required=False, description="시작 위치"),
+            OpenApiParameter(name="search", type=str, location="query", required=False, description="강의/강사명 검색"),
+        ],
+        responses={200: AdminLectureListSerializer(many=True)},  # pagination wrapper: {"count", "results"}
+    )
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        return super().get(request, *args, **kwargs)
+
+    def get_queryset(self) -> QuerySet[Lecture]:
+        qs: QuerySet[Lecture] = Lecture.objects.all().order_by("-created_at", "-pk")
+        keyword = self.request.query_params.get("search")
+        if keyword:
+            qs = qs.filter(Q(title__icontains=keyword) | Q(instructor__icontains=keyword))
+        return qs

--- a/config/urls.py
+++ b/config/urls.py
@@ -11,6 +11,7 @@ urlpatterns: list[URLPattern | URLResolver] = [
     path("api/v1/", include("apps.users.urls")),
     path("api/v1/admin/", include("apps.users.urls.admin_urls")),
     path("api/v1/admin/recruitments", include("apps.recruitments.urls.admin_recruitments_urls")),
+    path("api/v1/admin/lectures", include("apps.lectures.urls.admin_urls")),
     path("api/v1/notifications", include("apps.notifications.urls")),
     path("api/v1/recruitments", include("apps.recruitments.urls")),
     path("api/v1/schedules", include("apps.study_group_schedules.urls")),


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: 관리자 강의 목록  API를 만들었습니다

## 📄 상세 내용
- [ REQ-LECT-007 관리자 강의 목록 API 구현 ]
- [ 관리자/북마크 라우트 정렬 ] 
- [ 테스트 추가 ] 

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
