### PR TITLE
✨ feat: 관리자 권한 회원 탈퇴 복구 기능 추가

### DIFF
--- a/apps/users/serializers/admin_withdrawal_serializers.py
+++ b/apps/users/serializers/admin_withdrawal_serializers.py
@@ -40,7 +40,6 @@ class AdminWithdrawalDetailSerializer(serializers.ModelSerializer[Withdrawals]):
     class Meta:
         model = Withdrawals
         fields = [
-            "id",
             "name",
             "gender",
             "nickname",
@@ -49,6 +48,7 @@ class AdminWithdrawalDetailSerializer(serializers.ModelSerializer[Withdrawals]):
             "status",
             "user_joined_at",
             "profile_img_url",
+            "id",
             "created_at",
             "reason",
             "reason_detail",

--- a/apps/users/tests/test_admin_withdrawal.py
+++ b/apps/users/tests/test_admin_withdrawal.py
@@ -126,3 +126,59 @@ class WithdrawalAdminAPITest(APITestCase):
         # 탈퇴 요청일(created_at) 오름차순 정렬
         response = self.client.get(self.list_url, {"ordering": "created_at"})
         self.assertEqual(response.data["results"][0]["email"], self.withdrawn_staff.email)
+
+    def test_restore_user_success_as_admin(self) -> None:
+        """탈퇴 유저 신청한 유저 복구 테스트"""
+        # 관리자 권한 유저 복구 기능 테스트
+        self.client.force_authenticate(user=self.superuser)
+
+        # 복구 대상으로 지정할 객체
+        withdrawal_obj = Withdrawals.objects.get(user=self.withdrawn_staff)
+
+        # restore에 대한 URL 생성
+        restore_url = reverse("admin_user:admin-withdrawal-restore", kwargs={"pk": withdrawal_obj.pk})
+
+        # POST 요청 실행
+        response = self.client.post(restore_url)
+
+        # 1. 성공 응답
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["message"], "유저 복구가 완료 되었습니다.")
+
+        # 2. Withdrawals 테이블에서 해당 유저 삭제 여부 확인
+        self.assertFalse(Withdrawals.objects.filter(pk=withdrawal_obj.pk).exists())
+        self.withdrawn_staff.refresh_from_db()
+        self.assertTrue(self.withdrawn_staff.is_active)
+
+    def test_restore_user_success_as_staff(self) -> None:
+        # 스태프 권한 유저 복구 기능 테스트
+        self.client.force_authenticate(user=self.staff_user)
+
+        # 복구 대상으로 지정할 객체
+        withdrawal_obj = Withdrawals.objects.get(user=self.withdrawn_staff)
+
+        # restore에 대한 URL 생성
+        restore_url = reverse("admin_user:admin-withdrawal-restore", kwargs={"pk": withdrawal_obj.pk})
+
+        # POST 요청 실행
+        response = self.client.post(restore_url)
+
+        # 1. 성공 응답
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # 2. Withdrawals 테이블에서 해당 유저 삭제 여부 확인
+        self.assertFalse(Withdrawals.objects.filter(pk=withdrawal_obj.pk).exists())
+
+        # 3. User 모델의 is_active 상태 True 변경 여부 확인
+        self.withdrawn_staff.refresh_from_db()
+        self.assertTrue(self.withdrawn_staff.is_active)
+
+    def test_restore_user_fail_for_general_user(self) -> None:
+        """권한이 없는 유저가 복구 시도시 403 에러 반환 테스트"""
+        self.client.force_authenticate(user=self.general_user)
+
+        withdrawal_obj = Withdrawals.objects.get(user=self.withdrawn_staff)
+        restore_url = reverse("admin_user:admin-withdrawal-restore", kwargs={"pk": withdrawal_obj.pk})
+
+        response = self.client.post(restore_url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/apps/users/views/admin_withdrawal_view.py
+++ b/apps/users/views/admin_withdrawal_view.py
@@ -37,7 +37,7 @@ class WithdrawalAdminViewSet(viewsets.ReadOnlyModelViewSet[Withdrawals]):
             return AdminWithdrawalDetailSerializer
         return AdminWithdrawalListSerializer
 
-    # 'restore 요청에 복구 로직을 구현
+    # restore 요청에 복구 로직을 구현
     @action(detail=True, methods=["post"])
     def restore(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         """

--- a/apps/users/views/admin_withdrawal_view.py
+++ b/apps/users/views/admin_withdrawal_view.py
@@ -1,8 +1,12 @@
-from typing import Type, Union
+from typing import Any, Type, Union
 
+from django.db import transaction
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, viewsets
+from rest_framework.decorators import action
 from rest_framework.permissions import IsAdminUser
+from rest_framework.request import Request
+from rest_framework.response import Response
 
 from apps.users.filters import WithdrawalFilter
 from apps.users.models import Withdrawals
@@ -32,3 +36,21 @@ class WithdrawalAdminViewSet(viewsets.ReadOnlyModelViewSet[Withdrawals]):
         if self.action == "retrieve":
             return AdminWithdrawalDetailSerializer
         return AdminWithdrawalListSerializer
+
+    # 'restore 요청에 복구 로직을 구현
+    @action(detail=True, methods=["post"])
+    def restore(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """
+        URL: POST /api/v1/admin/withdrawals/{id}/restore
+        선택한 탈퇴 유저를 복구
+        """
+        with transaction.atomic():
+            withdrawal = self.get_object()
+            user = withdrawal.user
+
+            withdrawal.delete()
+
+            user.is_active = True
+            user.save(update_fields=["is_active", "updated_at"])
+
+        return Response({"message": "유저 복구가 완료 되었습니다."})


### PR DESCRIPTION
회원 관리 페이지 회원 탈퇴 복구 기능 구현

관련 이슈: #105

## ✅ PR 요약
- 관련 이슈 번호: #105 
- 작업 요약:  회원 관리 페이지에서 관리자 권한으로 탈퇴 신청한 유저를 복구할 수 있게 view 코드 추가

## 📄 상세 내용
- [x] 탈퇴 요청을 복구하기 위한 restore action 코드 추가 (view)
- [x] 탈퇴 회원 복구 action 코드를 위한 TEST CODE 추가

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
