### PR TITLE
금일 스터디 스케쥴 알림 생성

### DIFF
--- a/apps/notifications/services/noti_create_service.py
+++ b/apps/notifications/services/noti_create_service.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime, time, timedelta
-from typing import Dict, Iterable, List, Set, Tuple
+from typing import Dict, Iterable, Tuple
 
 from django.db.models import Prefetch, QuerySet
 from django.utils import timezone
@@ -8,6 +8,7 @@ from apps.applications.models.applications import Application
 from apps.notifications.const import get_notification_back_url
 from apps.notifications.models import Notification
 from apps.studies.models import GroupMember, StudyGroup
+from apps.study_group_schedules.models import GroupSchedule
 from apps.study_notes.models import StudyNote
 
 
@@ -213,6 +214,69 @@ class StudyReviewNotificationService:
         for group in groups.iterator(chunk_size=chunk_size):
             created = cls.create_review_request_notifications_for_group(group=group, today=today)
             stats["groups_processed"] += 1
+            stats["notifications_created"] += created
+
+        return stats
+
+
+class ScheduleTodayNotificationService:
+    @staticmethod
+    def time_format(d: date, t: time) -> str:
+        tz = timezone.get_current_timezone()
+        dt = timezone.make_aware(datetime.combine(d, t), tz)
+        ampm = "오전" if dt.hour < 12 else "오후"
+        h12 = (dt.hour - 1) % 12 + 1
+        return f"{ampm} {h12:02d}:{dt:%M}"
+
+    @classmethod
+    def build_notification_content(cls, gs: GroupSchedule) -> str:
+        start = cls.time_format(gs.session_date, gs.start_time)
+        end = cls.time_format(gs.session_date, gs.end_time)
+        group_name = gs.study_group.name
+        title = gs.title
+        return f"금일 {start}부터 {end}까지 {group_name}에서 {title}이(가) 예정되어 있습니다! 잊지말고 참여해주세요!"
+
+    @classmethod
+    def get_today_schedules(cls, d: date) -> QuerySet[GroupSchedule]:
+        return (
+            GroupSchedule.objects.filter(session_date=d)
+            .select_related("study_group")
+            .only("id", "title", "session_date", "start_time", "end_time", "study_group_id", "study_group__name")
+            .prefetch_related(Prefetch("participants", queryset=GroupMember.objects.only("id", "user_id")))
+        )
+
+    @classmethod
+    def notify_today_schedules(cls, gs: GroupSchedule) -> int:
+        member_ids = gs.participants.values_list("user_id", flat=True).distinct()
+        if not member_ids:
+            return 0
+
+        msg = cls.build_notification_content(gs)
+        notis = [
+            Notification(
+                user_id=uid,
+                content=msg,
+                notification_type=Notification.NotificationType.TODAY_SCHEDULE,
+                back_url_link=get_notification_back_url(
+                    Notification.NotificationType.TODAY_SCHEDULE, group_id=gs.study_group_id
+                ),
+            )
+            for uid in member_ids
+        ]
+        Notification.objects.bulk_create(notis, batch_size=1000)
+        return len(notis)
+
+    @classmethod
+    def notify_all_today_schedules(cls, today: date | None = None, chunk_size: int = 200) -> Dict[str, int]:
+        if today is None:
+            today = timezone.localdate()
+
+        schedules = cls.get_today_schedules(today)
+        stats = {"schedules_processed": 0, "notifications_created": 0}
+
+        for gs in schedules.iterator(chunk_size=chunk_size):
+            created = cls.notify_today_schedules(gs)
+            stats["schedules_processed"] += 1
             stats["notifications_created"] += created
 
         return stats

--- a/apps/notifications/tasks.py
+++ b/apps/notifications/tasks.py
@@ -3,6 +3,7 @@ from typing import Dict
 from celery import shared_task
 
 from apps.notifications.services.noti_create_service import (
+    ScheduleTodayNotificationService,
     StudyReviewNotificationService,
 )
 
@@ -10,3 +11,8 @@ from apps.notifications.services.noti_create_service import (
 @shared_task(name="apps.notifications.tasks.study_review_requests_for_groups")
 def study_review_requests_for_groups() -> Dict[str, int]:
     return StudyReviewNotificationService.create_review_request_notifications_for_due_group()
+
+
+@shared_task(name="apps.notifications.tasks.notify_today_schedules")
+def notify_today_schedules() -> Dict[str, int]:
+    return ScheduleTodayNotificationService.notify_all_today_schedules()

--- a/apps/notifications/tests/test_notify_today_schedule.py
+++ b/apps/notifications/tests/test_notify_today_schedule.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+from datetime import date, time, timedelta
+
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from apps.notifications.models import Notification
+from apps.notifications.services.noti_create_service import (
+    ScheduleTodayNotificationService as Svc,
+)
+from apps.notifications.tasks import notify_today_schedules
+from apps.studies.models.group_members import GroupMember
+from apps.studies.models.study_groups import StudyGroup
+from apps.study_group_schedules.models import GroupSchedule
+from apps.users.models.user import User
+
+
+@override_settings(TIME_ZONE="Asia/Seoul")
+class ScheduleTodayNotificationTests(TestCase):
+    def setUp(self) -> None:
+        self.group = StudyGroup.objects.create(
+            name="Python 기초 스터디",
+            introduction="intro",
+            max_headcount=5,
+            start_at=timezone.now(),
+            end_at=timezone.now(),
+            status=StudyGroup.StatusChoices.PENDING,
+        )
+        self.u1 = User.objects.create_user(
+            email="oz@example.com",
+            password="1q2w3e4r!",
+            nickname="author",
+            name="Author",
+            phone_number="01000000000",
+            gender="male",
+            birthday=date(1990, 1, 1),
+        )
+        self.u2 = User.objects.create_user(
+            email="ox@example.com",
+            password="1q2w3e4r@",
+            nickname="m1",
+            name="Member1",
+            phone_number="01011111111",
+            gender="male",
+            birthday=date(1993, 1, 1),
+        )
+        self.u3 = User.objects.create_user(
+            email="oc@example.com",
+            password="1q2w3e4r#",
+            nickname="m2",
+            name="Member2",
+            phone_number="01022222222",
+            gender="male",
+            birthday=date(1994, 1, 1),
+        )
+
+        self.m1 = GroupMember.objects.create(study_group=self.group, user=self.u1, is_leader=True)
+        self.m2 = GroupMember.objects.create(study_group=self.group, user=self.u2, is_leader=False)
+        self.m3 = GroupMember.objects.create(study_group=self.group, user=self.u3, is_leader=False)
+
+        # 오늘/내일 기준 날짜
+        self.today = timezone.localdate()
+        self.tomorrow = self.today + timedelta(days=1)
+
+    def add_participants(self, gs: GroupSchedule) -> None:
+        """
+        participants(M2M=GroupMember) 채우기
+        """
+        gs.participants.add(self.m1, self.m2, self.m3)
+
+    # -------- 포맷팅 테스트 --------
+    def test_build_message_formats_correctly(self) -> None:
+        gs = GroupSchedule.objects.create(
+            study_group=self.group,
+            title="자료형 학습",
+            objective="목표",
+            session_date=self.today,
+            start_time=time(9, 30),
+            end_time=time(13, 30),
+        )
+        msg = Svc.build_notification_content(gs)
+        # 오전/오후 + 12시간 형식 “오전 09:30 … 오후 01:30 … 그룹명 … 스케줄명”
+        self.assertIn("오전 09:30", msg)
+        self.assertIn("오후 01:30", msg)
+        self.assertIn(self.group.name, msg)
+        self.assertIn(gs.title, msg)
+
+    # -------- 조회 테스트 --------
+    def test_get_todays_schedules_filters_by_session_date(self) -> None:
+        # 오늘 스케줄 2개 / 내일 스케줄 1개
+        a = GroupSchedule.objects.create(
+            study_group=self.group,
+            title="A",
+            objective="o",
+            session_date=self.today,
+            start_time=time(9, 0),
+            end_time=time(10, 0),
+        )
+        b = GroupSchedule.objects.create(
+            study_group=self.group,
+            title="B",
+            objective="o",
+            session_date=self.today,
+            start_time=time(11, 0),
+            end_time=time(12, 0),
+        )
+        GroupSchedule.objects.create(
+            study_group=self.group,
+            title="C",
+            objective="o",
+            session_date=self.tomorrow,
+            start_time=time(9, 0),
+            end_time=time(10, 0),
+        )
+
+        qs = Svc.get_today_schedules(self.today)
+        ids = set(qs.values_list("id", flat=True))
+        self.assertEqual(ids, {a.id, b.id})
+
+    # -------- 단일 스케줄 발송 테스트 --------
+    def test_notify_today_for_schedule_creates_notifications_for_participants(self) -> None:
+        gs = GroupSchedule.objects.create(
+            study_group=self.group,
+            title="자료형 학습",
+            objective="o",
+            session_date=self.today,
+            start_time=time(9, 30),
+            end_time=time(13, 30),
+        )
+        self.add_participants(gs)
+
+        created = Svc.notify_today_schedules(gs)
+        self.assertEqual(created, 3)
+
+        rows = Notification.objects.filter(notification_type=Notification.NotificationType.TODAY_SCHEDULE).order_by(
+            "user_id"
+        )
+
+        self.assertEqual(rows.count(), 3)
+        for r in rows:
+            self.assertTrue(str(self.group.id) in r.back_url_link)
+            self.assertIn("금일", r.content)
+
+    def test_notify_today_for_schedule_when_no_participants(self) -> None:
+        gs = GroupSchedule.objects.create(
+            study_group=self.group,
+            title="빈 스케줄",
+            objective="o",
+            session_date=self.today,
+            start_time=time(9, 0),
+            end_time=time(10, 0),
+        )
+        created = Svc.notify_today_schedules(gs)
+        self.assertEqual(created, 0)
+        self.assertEqual(
+            Notification.objects.filter(notification_type=Notification.NotificationType.TODAY_SCHEDULE).count(),
+            0,
+        )
+
+    # -------- 배치(태스크) 테스트 --------
+    def test_task_notify_today_schedules(self) -> None:
+        # 오늘 스케줄 2개(각 3명 참가) → 총 6건
+        a = GroupSchedule.objects.create(
+            study_group=self.group,
+            title="A",
+            objective="o",
+            session_date=self.today,
+            start_time=time(8, 0),
+            end_time=time(10, 0),
+        )
+        b = GroupSchedule.objects.create(
+            study_group=self.group,
+            title="B",
+            objective="o",
+            session_date=self.today,
+            start_time=time(11, 0),
+            end_time=time(12, 0),
+        )
+        self.add_participants(a)
+        self.add_participants(b)
+
+        stats = notify_today_schedules()
+        self.assertEqual(stats["schedules_processed"], 2)
+        self.assertEqual(stats["notifications_created"], 6)
+
+        self.assertEqual(
+            Notification.objects.filter(notification_type=Notification.NotificationType.TODAY_SCHEDULE).count(),
+            6,
+        )

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -248,4 +248,8 @@ CELERY_BEAT_SCHEDULE = {
         "task": "apps.notifications.tasks.study_review_requests_for_groups",
         "schedule": crontab(hour=0, minute=10),
     },
+    "notify_today_schedules": {
+        "task": "apps.notifications.tasks.notify_today_schedules",
+        "schedule": crontab(hour=0, minute=1),
+    },
 }


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #174
- 작업 요약: 매일 00시 01분 부터 배치작업을 통해 모든 스터디 그룹의 스케줄중 당일에 해당하는 스케줄에 대해서 해당 스케줄 참가인원들에게 스케줄 당일 알림 발생

## 📄 상세 내용
- [x] 00시01분 배치작업을 위한 celery-beat 및 task 작성
- [x] 알림 생성 로직 서비스 레이어에 작성
- [x] 관련 테스트코드 작성

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
sse 추후 연동 예정
## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
