### PR TITLE
✨ feat: 어드민 공고 목록 조회 및 태그 검색/필터링 적용

### DIFF
--- a/apps/recruitments/filtering.py
+++ b/apps/recruitments/filtering.py
@@ -1,0 +1,54 @@
+from django.db import models
+from rest_framework.request import Request
+
+from apps.recruitments.models import Recruitment
+
+
+class CustomRecruitmentFilter:
+    def __init__(self, request: Request, queryset: models.QuerySet[Recruitment]):
+        self.request = request
+        self.queryset = queryset
+
+    def filter_queryset(self) -> models.QuerySet[Recruitment]:
+        """요청 파라미터를 기반으로 쿼리셋에 모든 필터를 순차적으로 적용합니다."""
+        self.queryset = self._filter_by_status()
+        self.queryset = self._filter_by_tags()
+        self.queryset = self._apply_search()
+        self.queryset = self._apply_ordering()
+        return self.queryset
+
+    def _filter_by_status(self) -> models.QuerySet[Recruitment]:
+        status_param = self.request.query_params.get("status")
+        if status_param == "recruiting":
+            return self.queryset.filter(is_closed=False)
+        if status_param == "closed":
+            return self.queryset.filter(is_closed=True)
+        return self.queryset
+
+    def _filter_by_tags(self) -> models.QuerySet[Recruitment]:
+        tags_param = self.request.query_params.get("tags")
+        if tags_param:
+            tag_ids = [int(tag_id) for tag_id in tags_param.split(",") if tag_id.isdigit()]
+            if tag_ids:
+                return self.queryset.filter(tags__id__in=tag_ids).distinct()
+        return self.queryset
+
+    def _apply_search(self) -> models.QuerySet[Recruitment]:
+        search_param = self.request.query_params.get("search")
+        if search_param:
+            return self.queryset.filter(title__icontains=search_param)
+        return self.queryset
+
+    def _apply_ordering(self) -> models.QuerySet[Recruitment]:
+        ordering_param = self.request.query_params.get("ordering", "-created_at")
+        valid_ordering_fields = [
+            "created_at",
+            "-created_at",
+            "views_count",
+            "-views_count",
+            "bookmark_count",
+            "-bookmark_count",
+        ]
+        if ordering_param in valid_ordering_fields:
+            return self.queryset.order_by(ordering_param)
+        return self.queryset

--- a/apps/recruitments/managers/__init__.py
+++ b/apps/recruitments/managers/__init__.py
@@ -1,0 +1,3 @@
+from .managers_list import AdminRecruitmentManager, RecruitmentListManager
+
+__all__ = ["AdminRecruitmentManager", "RecruitmentListManager"]

--- a/apps/recruitments/managers/managers_list.py
+++ b/apps/recruitments/managers/managers_list.py
@@ -16,7 +16,7 @@ class RecruitmentListQuerySet(models.QuerySet["Recruitment"]):
     def filter_is_closed(self) -> Self:
         return self.filter(is_closed=False)
 
-    def order_last(self) -> Self:
+    def sort_by_latest(self) -> Self:
         return self.order_by("-created_at")
 
     def recm_list_queryset(self) -> Self:

--- a/apps/recruitments/managers/managers_list.py
+++ b/apps/recruitments/managers/managers_list.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Self, cast
 
 from django.apps import apps
 from django.db import models
@@ -13,13 +13,13 @@ if TYPE_CHECKING:
 
 
 class RecruitmentListQuerySet(models.QuerySet["Recruitment"]):
-    def filter_is_closed(self) -> RecruitmentListQuerySet:
+    def filter_is_closed(self) -> Self:
         return self.filter(is_closed=False)
 
-    def order_last(self) -> RecruitmentListQuerySet:
+    def order_last(self) -> Self:
         return self.order_by("-created_at")
 
-    def recm_list_queryset(self) -> RecruitmentListQuerySet:
+    def recm_list_queryset(self) -> Self:
         # 순환참조를 피하기 위해서 'images'라는 역방향 관계 필드를 이용해 모델 class 이용
         reverse_relation = self.model._meta.get_field("images")
         RecruitmentImage = cast("RecruitmentImage", reverse_relation.related_model)
@@ -44,3 +44,19 @@ if TYPE_CHECKING:
 
 else:
     RecruitmentListManager = _RecruitmentListManager
+
+
+class AdminRecruitmentQuerySet(models.QuerySet["Recruitment"]):
+    def with_counts(self) -> Self:
+        return self.annotate(bookmark_count=Count("bookmark_users", distinct=True))
+
+    def prefetch_tags(self) -> Self:
+        return self.prefetch_related("tags")
+
+
+class AdminRecruitmentManager(models.Manager["Recruitment"]):
+    def get_queryset(self) -> AdminRecruitmentQuerySet:
+        return AdminRecruitmentQuerySet(self.model, using=self._db)
+
+    def get_admin_listings(self) -> AdminRecruitmentQuerySet:
+        return self.get_queryset().with_counts().prefetch_tags()

--- a/apps/recruitments/models/recruitments.py
+++ b/apps/recruitments/models/recruitments.py
@@ -6,7 +6,10 @@ from django.db.models import Q
 from django.utils import timezone
 
 from apps.core.models.base import UUIDBaseModel
-from apps.recruitments.managers.managers_list import RecruitmentListManager
+from apps.recruitments.managers import (
+    AdminRecruitmentManager,
+    RecruitmentListManager,
+)
 from apps.recruitments.models.tags import Tag
 from apps.studies.models import StudyGroup
 from apps.users.models.user import User
@@ -63,6 +66,9 @@ class Recruitment(UUIDBaseModel):
 
     # 공고 리스트에서 사용 manager
     object_list = RecruitmentListManager()
+
+    # 관리자 페이지용 manager
+    admin_objects = AdminRecruitmentManager()
 
     def __str__(self) -> str:
         return self.title

--- a/apps/recruitments/serializers/recruitments_serializers.py
+++ b/apps/recruitments/serializers/recruitments_serializers.py
@@ -40,6 +40,30 @@ class LectureSerializer(serializers.ModelSerializer[Lecture]):
         ]
 
 
+class AdminRecruitmentListSerializer(serializers.ModelSerializer[Recruitment]):
+    tags = TagSerializer(many=True, read_only=True)
+    status = serializers.SerializerMethodField()
+    bookmark_count = serializers.IntegerField()
+
+    class Meta:
+        model = Recruitment
+        fields = [
+            "id",
+            "uuid",
+            "title",
+            "tags",
+            "close_at",
+            "status",
+            "views_count",
+            "bookmark_count",
+            "created_at",
+            "updated_at",
+        ]
+
+    def get_status(self, obj: Recruitment) -> str:
+        return "closed" if obj.is_closed else "recruiting"
+
+
 class RecruitmentDetailSerializer(serializers.ModelSerializer[Recruitment]):
     author = UserSerializer(read_only=True)
     attachments = RecruitmentAttachmentSerializer(many=True, read_only=True)

--- a/apps/recruitments/services/services_list.py
+++ b/apps/recruitments/services/services_list.py
@@ -6,7 +6,7 @@ from apps.users.models.user import User
 def get_recm_list() -> RecruitmentListQuerySet:
     # 마감된 공고는 필터하고 최신순을 기본 정렬로 함
     # 시리얼라이저 정보 최적화하여 채워넣기
-    queryset = Recruitment.object_list.filter_is_closed().order_last().recm_list_queryset()
+    queryset = Recruitment.object_list.filter_is_closed().sort_by_latest().recm_list_queryset()
     return queryset
 
 
@@ -16,7 +16,7 @@ def filter_tag(queryset: RecruitmentListQuerySet, tag: str) -> RecruitmentListQu
 
 
 def get_my_recm_list(user: User) -> RecruitmentListQuerySet:
-    queryset = Recruitment.object_list.order_last().recm_list_queryset().filter(author=user)
+    queryset = Recruitment.object_list.sort_by_latest().recm_list_queryset().filter(author=user)
     return queryset
 
 

--- a/apps/recruitments/tests/test_admin_recruitments.py
+++ b/apps/recruitments/tests/test_admin_recruitments.py
@@ -1,0 +1,191 @@
+from datetime import date, timedelta
+
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.recruitments.models import Recruitment, Tag
+from apps.studies.models import StudyGroup
+from apps.users.models import User
+
+
+class AdminRecruitmentListViewTest(APITestCase):
+    """
+    관리자용 구인 공고 목록 조회 API 테스트
+    (REQ-RECM-012, REQ-RECM-013)
+    """
+
+    admin_user: User
+    normal_user: User
+    recruitment1: Recruitment
+    recruitment2: Recruitment
+    recruitment3: Recruitment
+    tag_django: Tag
+    tag_python: Tag
+    url: str
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        # 1. GIVEN: 유저 생성 (관리자, 일반 사용자)
+        cls.admin_user = User.objects.create_user(
+            email="admin@test.com",
+            password="password",
+            is_staff=True,
+            name="관리자",
+            nickname="admin_nick",
+            phone_number="010-0000-0000",
+            gender="M",
+            birthday=date(1990, 1, 1),
+        )
+        cls.normal_user = User.objects.create_user(
+            email="user@test.com",
+            password="password",
+            name="일반유저",
+            nickname="user_nick",
+            phone_number="010-1111-1111",
+            gender="F",
+            birthday=date(1995, 1, 1),
+        )
+
+        # 테스트용 스터디 그룹 생성
+        study_group = StudyGroup.objects.create(
+            name="테스트 스터디", max_headcount=5, start_at=timezone.now(), end_at=timezone.now() + timedelta(days=30)
+        )
+
+        # 테스트용 태그 생성
+        cls.tag_django = Tag.objects.create(name="Django")
+        cls.tag_python = Tag.objects.create(name="Python")
+
+        # 2. GIVEN: 다양한 속성을 가진 공고 데이터 생성
+        # 공고 1: 모집중, 조회수 100, 북마크 1개, 태그: Django, Python
+        cls.recruitment1 = Recruitment.objects.create(
+            author=cls.admin_user,
+            study_group=study_group,
+            title="[모집중] Django 스터디",
+            content="내용1",
+            is_closed=False,
+            views_count=100,
+            created_at=timezone.now() - timedelta(days=2),
+            expected_headcount=5,
+            estimated_fee=10000,
+        )
+        cls.recruitment1.tags.add(cls.tag_django, cls.tag_python)
+        cls.recruitment1.bookmark_users.add(cls.normal_user)
+
+        # 공고 2: 마감, 조회수 200, 북마크 2개, 태그: Python
+        cls.recruitment2 = Recruitment.objects.create(
+            author=cls.admin_user,
+            study_group=study_group,
+            title="[마감] Python 스터디",
+            content="내용2",
+            is_closed=True,
+            views_count=200,
+            created_at=timezone.now() - timedelta(days=1),
+            expected_headcount=5,
+            estimated_fee=10000,
+        )
+        cls.recruitment2.tags.add(cls.tag_python)
+        cls.recruitment2.bookmark_users.add(cls.normal_user, cls.admin_user)
+
+        # 공고 3: 모집중, 조회수 50, 북마크 0개, 태그 없음
+        cls.recruitment3 = Recruitment.objects.create(
+            author=cls.admin_user,
+            study_group=study_group,
+            title="[모집중] 알고리즘 스터디",
+            content="내용3",
+            is_closed=False,
+            views_count=50,
+            created_at=timezone.now(),
+            expected_headcount=5,
+            estimated_fee=10000,
+        )
+
+        cls.url = reverse("admin-recruitment-list")
+
+    def test_permission_denied_for_anonymous_user(self) -> None:
+        """권한 테스트: 비인증 유저 접근 시 401 에러 확인"""
+        # WHEN
+        response = self.client.get(self.url)
+        # THEN
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_permission_denied_for_normal_user(self) -> None:
+        """권한 테스트: 일반 유저 접근 시 403 에러 확인"""
+        # GIVEN
+        self.client.force_authenticate(user=self.normal_user)
+        # WHEN
+        response = self.client.get(self.url)
+        # THEN
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_get_list_success_for_admin(self) -> None:
+        """기능 테스트: 관리자 기본 목록 조회 성공"""
+        # GIVEN
+        self.client.force_authenticate(user=self.admin_user)
+        # WHEN
+        response = self.client.get(self.url)
+        # THEN
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 3)
+        # 기본 정렬(최신순) 확인
+        self.assertEqual(response.data["results"][0]["id"], self.recruitment3.id)
+
+    def test_search_filter(self) -> None:
+        """기능 테스트: 제목 검색 기능 확인"""
+        # GIVEN
+        self.client.force_authenticate(user=self.admin_user)
+        # WHEN
+        response = self.client.get(self.url, {"search": "Django"})
+        # THEN
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["id"], self.recruitment1.id)
+
+    def test_status_filter(self) -> None:
+        """기능 테스트: 상태 필터링 기능 확인"""
+        # GIVEN
+        self.client.force_authenticate(user=self.admin_user)
+        # WHEN
+        response_recruiting = self.client.get(self.url, {"status": "recruiting"})
+        response_closed = self.client.get(self.url, {"status": "closed"})
+        # THEN
+        self.assertEqual(response_recruiting.data["count"], 2)
+        self.assertEqual(response_closed.data["count"], 1)
+        self.assertEqual(response_closed.data["results"][0]["id"], self.recruitment2.id)
+
+    def test_tags_filter(self) -> None:
+        """기능 테스트: 태그 필터링 기능 확인 (단일/다중)"""
+        # GIVEN
+        self.client.force_authenticate(user=self.admin_user)
+        # WHEN: 단일 태그(Django) 필터링
+        response_django = self.client.get(self.url, {"tags": self.tag_django.id})
+        # THEN
+        self.assertEqual(response_django.data["count"], 1)
+        self.assertEqual(response_django.data["results"][0]["id"], self.recruitment1.id)
+
+        # WHEN: 단일 태그(Python) 필터링
+        response_python = self.client.get(self.url, {"tags": self.tag_python.id})
+        # THEN
+        self.assertEqual(response_python.data["count"], 2)
+
+        # WHEN: 다중 태그 필터링
+        response_multiple = self.client.get(self.url, {"tags": f"{self.tag_django.id},{self.tag_python.id}"})
+        # THEN: Django 또는 Python 태그를 가진 공고는 2개
+        self.assertEqual(response_multiple.data["count"], 2)
+
+    def test_ordering(self) -> None:
+        """기능 테스트: 정렬 기능 확인"""
+        # GIVEN
+        self.client.force_authenticate(user=self.admin_user)
+        # WHEN: 조회수 순 정렬
+        response_views = self.client.get(self.url, {"ordering": "-views_count"})
+        # THEN
+        self.assertEqual(response_views.data["results"][0]["id"], self.recruitment2.id)
+        self.assertEqual(response_views.data["results"][1]["id"], self.recruitment1.id)
+
+        # WHEN: 북마크 순 정렬
+        response_bookmarks = self.client.get(self.url, {"ordering": "-bookmark_count"})
+        # THEN
+        self.assertEqual(response_bookmarks.data["results"][0]["id"], self.recruitment2.id)
+        self.assertEqual(response_bookmarks.data["results"][1]["id"], self.recruitment1.id)

--- a/apps/recruitments/urls/admin_recruitments_urls.py
+++ b/apps/recruitments/urls/admin_recruitments_urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from apps.recruitments.views.admin_recruitments_views import AdminRecruitmentListView
+
+urlpatterns = [
+    path("", AdminRecruitmentListView.as_view(), name="admin-recruitment-list"),
+]

--- a/apps/recruitments/views/admin_recruitments_views.py
+++ b/apps/recruitments/views/admin_recruitments_views.py
@@ -1,0 +1,21 @@
+from django.db import models
+from rest_framework import generics
+from rest_framework.permissions import IsAdminUser
+
+from apps.recruitments.filtering import CustomRecruitmentFilter
+from apps.recruitments.models import Recruitment
+from apps.recruitments.serializers.recruitments_serializers import (
+    AdminRecruitmentListSerializer,
+)
+
+
+class AdminRecruitmentListView(generics.ListAPIView[Recruitment]):
+    serializer_class = AdminRecruitmentListSerializer
+    permission_classes = [IsAdminUser]
+
+    def get_queryset(self) -> models.QuerySet[Recruitment]:
+        base_queryset = Recruitment.admin_objects.get_admin_listings()
+
+        # 커스텀 필터 클래스를 사용하여 필터링 로직 위임
+        custom_filter = CustomRecruitmentFilter(request=self.request, queryset=base_queryset)
+        return custom_filter.filter_queryset()

--- a/config/urls.py
+++ b/config/urls.py
@@ -10,6 +10,7 @@ from drf_spectacular.views import (
 urlpatterns: list[URLPattern | URLResolver] = [
     path("api/v1/", include("apps.users.urls")),
     path("api/v1/admin/", include("apps.users.urls.admin_urls")),
+    path("api/v1/admin/recruitments", include("apps.recruitments.urls.admin_recruitments_urls")),
     path("api/v1/notifications", include("apps.notifications.urls")),
     path("api/v1/recruitments", include("apps.recruitments.urls")),
     path("api/v1/schedules", include("apps.study_group_schedules.urls")),


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #176 
- 작업 요약: 어드민 공고 목록 조회 기능 개발

## 📄 상세 내용
- [ ] 관리자용 구인 공고 목록 조회 API 구현 GET /api/v1/admin/recruitments)
- [ ] 관리자(IsAdminUser)만 접근 가능하도록 권한 설정
- [ ] 공고명 검색, 상태 및 태그 기반의 필터링 기능 추가 (CustomRecruitmentFilter 구현)
- [ ] 쿼리 파라미터를 이용한 정렬 기능 추가 (최신순, 조회수, 북마크순)
- [ ] Limit-Offset 기반 페이지네이션 적용
- [ ] 관련 기능에 대한 단위 테스트 코드 작성

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
