### PR TITLE
예정 스케쥴 알림

### DIFF
--- a/apps/notifications/services/noti_create_service.py
+++ b/apps/notifications/services/noti_create_service.py
@@ -280,3 +280,57 @@ class ScheduleTodayNotificationService:
             stats["notifications_created"] += created
 
         return stats
+
+
+class ScheduleUpComingNotificationService:
+    @classmethod
+    def get_tomorrow_schedules(cls, d: date) -> QuerySet[GroupSchedule]:
+        target = d + timedelta(days=1)
+        return (
+            GroupSchedule.objects.filter(session_date=target)
+            .select_related("study_group")
+            .only("id", "title", "session_date", "study_group_id", "study_group__name")
+            .prefetch_related(Prefetch("participants", queryset=GroupMember.objects.only("id", "user_id")))
+        )
+
+    @staticmethod
+    def build_notification_content(gs: GroupSchedule) -> str:
+        group_name = gs.study_group.name
+        title = gs.title
+        return f"내일은 {group_name}에서 {title}이(가) 예정되어 있습니다! 잊지말고 참여해주세요!"
+
+    @classmethod
+    def notify_upcoming_schedules(cls, gs: GroupSchedule) -> int:
+        member_ids = gs.participants.values_list("user_id", flat=True).distinct()
+        if not member_ids:
+            return 0
+
+        msg = cls.build_notification_content(gs)
+        notis = [
+            Notification(
+                user_id=uid,
+                content=msg,
+                notification_type=Notification.NotificationType.UPCOMING_SCHEDULE,
+                back_url_link=get_notification_back_url(
+                    Notification.NotificationType.UPCOMING_SCHEDULE, group_id=gs.study_group_id
+                ),
+            )
+            for uid in member_ids
+        ]
+        Notification.objects.bulk_create(notis, batch_size=1000)
+        return len(notis)
+
+    @classmethod
+    def notify_all_upcoming_schedules(cls, today: date | None = None, chunk_size: int = 200) -> Dict[str, int]:
+        if today is None:
+            today = timezone.localdate()
+
+        qs = cls.get_tomorrow_schedules(today)
+
+        stats = {"schedules_processed": 0, "notifications_created": 0}
+        for gs in qs.iterator(chunk_size=chunk_size):
+            created = cls.notify_upcoming_schedules(gs)
+            stats["schedules_processed"] += 1
+            stats["notifications_created"] += created
+
+        return stats

--- a/apps/notifications/tasks.py
+++ b/apps/notifications/tasks.py
@@ -4,6 +4,7 @@ from celery import shared_task
 
 from apps.notifications.services.noti_create_service import (
     ScheduleTodayNotificationService,
+    ScheduleUpComingNotificationService,
     StudyReviewNotificationService,
 )
 
@@ -16,3 +17,8 @@ def study_review_requests_for_groups() -> Dict[str, int]:
 @shared_task(name="apps.notifications.tasks.notify_today_schedules")
 def notify_today_schedules() -> Dict[str, int]:
     return ScheduleTodayNotificationService.notify_all_today_schedules()
+
+
+@shared_task(name="apps.notifications.tasks.notify_upcoming_schedules")
+def notify_upcoming_schedules() -> Dict[str, int]:
+    return ScheduleUpComingNotificationService.notify_all_upcoming_schedules()

--- a/apps/notifications/tests/test_notify_upcoming_schedule.py
+++ b/apps/notifications/tests/test_notify_upcoming_schedule.py
@@ -102,7 +102,7 @@ class ScheduleUpComigNotificationTests(TestCase):
             start_time=time(11, 0),
             end_time=time(12, 0),
         )
-        c =GroupSchedule.objects.create(
+        c = GroupSchedule.objects.create(
             study_group=self.group,
             title="C",
             objective="o",

--- a/apps/notifications/tests/test_notify_upcoming_schedule.py
+++ b/apps/notifications/tests/test_notify_upcoming_schedule.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from datetime import date, time, timedelta
+
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from apps.notifications.models import Notification
+from apps.notifications.services.noti_create_service import (
+    ScheduleUpComingNotificationService as Svc,
+)
+from apps.notifications.tasks import notify_upcoming_schedules
+from apps.studies.models.group_members import GroupMember
+from apps.studies.models.study_groups import StudyGroup
+from apps.study_group_schedules.models import GroupSchedule
+from apps.users.models.user import User
+
+
+@override_settings(TIME_ZONE="Asia/Seoul")
+class ScheduleUpComigNotificationTests(TestCase):
+    def setUp(self) -> None:
+        self.group = StudyGroup.objects.create(
+            name="Python 기초 스터디",
+            introduction="intro",
+            max_headcount=5,
+            start_at=timezone.now(),
+            end_at=timezone.now(),
+            status=StudyGroup.StatusChoices.PENDING,
+        )
+        self.u1 = User.objects.create_user(
+            email="oz@example.com",
+            password="1q2w3e4r!",
+            nickname="author",
+            name="Author",
+            phone_number="01000000000",
+            gender="male",
+            birthday=date(1990, 1, 1),
+        )
+        self.u2 = User.objects.create_user(
+            email="ox@example.com",
+            password="1q2w3e4r@",
+            nickname="m1",
+            name="Member1",
+            phone_number="01011111111",
+            gender="male",
+            birthday=date(1993, 1, 1),
+        )
+        self.u3 = User.objects.create_user(
+            email="oc@example.com",
+            password="1q2w3e4r#",
+            nickname="m2",
+            name="Member2",
+            phone_number="01022222222",
+            gender="male",
+            birthday=date(1994, 1, 1),
+        )
+
+        self.m1 = GroupMember.objects.create(study_group=self.group, user=self.u1, is_leader=True)
+        self.m2 = GroupMember.objects.create(study_group=self.group, user=self.u2, is_leader=False)
+        self.m3 = GroupMember.objects.create(study_group=self.group, user=self.u3, is_leader=False)
+
+        # 오늘/내일 기준 날짜
+        self.today = timezone.localdate()
+        self.tomorrow = self.today + timedelta(days=1)
+
+    def add_participants(self, gs: GroupSchedule) -> None:
+        """
+        participants(M2M=GroupMember) 채우기
+        """
+        gs.participants.add(self.m1, self.m2, self.m3)
+
+    # -------- 포맷팅 테스트 --------
+    def test_build_message_formats_correctly(self) -> None:
+        gs = GroupSchedule.objects.create(
+            study_group=self.group,
+            title="자료형 학습",
+            objective="목표",
+            session_date=self.today,
+            start_time=time(9, 30),
+            end_time=time(13, 30),
+        )
+        msg = Svc.build_notification_content(gs)
+        self.assertIn(self.group.name, msg)
+        self.assertIn(gs.title, msg)
+
+    # -------- 조회 테스트 --------
+    def test_get_tomorrow_schedules_filters_by_session_date(self) -> None:
+        # 오늘 스케줄 2개 / 내일 스케줄 1개
+        a = GroupSchedule.objects.create(
+            study_group=self.group,
+            title="A",
+            objective="o",
+            session_date=self.today,
+            start_time=time(9, 0),
+            end_time=time(10, 0),
+        )
+        b = GroupSchedule.objects.create(
+            study_group=self.group,
+            title="B",
+            objective="o",
+            session_date=self.today,
+            start_time=time(11, 0),
+            end_time=time(12, 0),
+        )
+        c =GroupSchedule.objects.create(
+            study_group=self.group,
+            title="C",
+            objective="o",
+            session_date=self.tomorrow,
+            start_time=time(9, 0),
+            end_time=time(10, 0),
+        )
+
+        qs = Svc.get_tomorrow_schedules(self.today)
+        ids = set(qs.values_list("id", flat=True))
+        self.assertEqual(ids, {c.id})
+
+    # -------- 단일 스케줄 발송 테스트 --------
+    def test_notify_tomorrow_for_schedule_creates_notifications_for_participants(self) -> None:
+        gs = GroupSchedule.objects.create(
+            study_group=self.group,
+            title="자료형 학습",
+            objective="o",
+            session_date=self.today,
+            start_time=time(9, 30),
+            end_time=time(13, 30),
+        )
+        self.add_participants(gs)
+
+        created = Svc.notify_upcoming_schedules(gs)
+        self.assertEqual(created, 3)
+
+        rows = Notification.objects.filter(notification_type=Notification.NotificationType.UPCOMING_SCHEDULE).order_by(
+            "user_id"
+        )
+
+        self.assertEqual(rows.count(), 3)
+        for r in rows:
+            self.assertTrue(str(self.group.id) in r.back_url_link)
+            self.assertIn("내일은", r.content)
+
+    def test_notify_tomorrow_for_schedule_when_no_participants(self) -> None:
+        gs = GroupSchedule.objects.create(
+            study_group=self.group,
+            title="빈 스케줄",
+            objective="o",
+            session_date=self.today,
+            start_time=time(9, 0),
+            end_time=time(10, 0),
+        )
+        created = Svc.notify_upcoming_schedules(gs)
+        self.assertEqual(created, 0)
+        self.assertEqual(
+            Notification.objects.filter(notification_type=Notification.NotificationType.UPCOMING_SCHEDULE).count(),
+            0,
+        )
+
+    # -------- 배치(태스크) 테스트 --------
+    def test_task_notify_upcomig_schedules(self) -> None:
+        # 내일 스케줄 1개(3명 참가) → 총 3건
+        a = GroupSchedule.objects.create(
+            study_group=self.group,
+            title="A",
+            objective="o",
+            session_date=self.today + timedelta(days=1),
+            start_time=time(8, 0),
+            end_time=time(10, 0),
+        )
+        b = GroupSchedule.objects.create(
+            study_group=self.group,
+            title="B",
+            objective="o",
+            session_date=self.today,
+            start_time=time(11, 0),
+            end_time=time(12, 0),
+        )
+        self.add_participants(a)
+        self.add_participants(b)
+
+        stats = notify_upcoming_schedules()
+        self.assertEqual(stats["schedules_processed"], 1)
+        self.assertEqual(stats["notifications_created"], 3)
+
+        self.assertEqual(
+            Notification.objects.filter(notification_type=Notification.NotificationType.UPCOMING_SCHEDULE).count(),
+            3,
+        )

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -252,4 +252,8 @@ CELERY_BEAT_SCHEDULE = {
         "task": "apps.notifications.tasks.notify_today_schedules",
         "schedule": crontab(hour=0, minute=1),
     },
+    "notify_upcomig_schedules": {
+        "task": "apps.notifications.tasks.notify_upcoming_schedules",
+        "schedule": crontab(hour=0, minute=1),
+    },
 }


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #185
- 작업 요약: 매일 00시 01분 부터 배치작업을 통해 모든 스터디 그룹의 스케줄 중에 하루전에 임박한 스케줄에 대해서 해당 스케줄 참가인원들에게 스케줄 예정 알림 발생

## 📄 상세 내용
- [x] celery-beat 통한 매일 00시 01분 부터 배치작업 구현
- [x] 서비스 레이어에 예정 스케쥴 알림 생성 로직 작성
- [x] 관련 테스트 코드 작성
## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
sse 추후 연동 예정
## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
