### PR TITLE
✨feat:스터디 구인공고 지원 승인 거부 기능 api

### DIFF
--- a/apps/applications/applications_permissions.py
+++ b/apps/applications/applications_permissions.py
@@ -3,6 +3,7 @@ from rest_framework.request import Request
 from rest_framework.views import APIView
 
 from apps.applications.models import Application
+from apps.recruitments.models import Recruitment
 from apps.users.models import User
 
 
@@ -30,3 +31,23 @@ class IsApplicantOrRecruiter(BasePermission):
         is_applicant = obj.user == user
         is_recruiter = obj.recruitment is not None and obj.recruitment.author == user
         return is_applicant or is_recruiter
+
+    @staticmethod
+    def _is_recruiter(user: User, obj: Application) -> bool:
+        if not user or not user.is_authenticated:
+            return False
+        return getattr(obj.recruitment, "author", None) == user
+
+
+class IsRecruiterOnly(BasePermission):
+    def has_object_permission(self, request: Request, view: APIView, obj: Application) -> bool:
+        if not request.user or not request.user.is_authenticated:
+            return False
+        # obj.recruitment.author가 현재 사용자와 같으면 True
+        return obj.recruitment is not None and obj.recruitment.author == request.user
+
+    @staticmethod
+    def has_permission_for_user(user: User, obj: Application) -> bool:
+        if not user.is_authenticated:
+            return False
+        return obj.recruitment is not None and obj.recruitment.author == user

--- a/apps/applications/applications_permissions.py
+++ b/apps/applications/applications_permissions.py
@@ -32,12 +32,6 @@ class IsApplicantOrRecruiter(BasePermission):
         is_recruiter = obj.recruitment is not None and obj.recruitment.author == user
         return is_applicant or is_recruiter
 
-    @staticmethod
-    def _is_recruiter(user: User, obj: Application) -> bool:
-        if not user or not user.is_authenticated:
-            return False
-        return getattr(obj.recruitment, "author", None) == user
-
 
 class IsRecruiterOnly(BasePermission):
     def has_object_permission(self, request: Request, view: APIView, obj: Application) -> bool:

--- a/apps/applications/applications_permissions.py
+++ b/apps/applications/applications_permissions.py
@@ -3,15 +3,11 @@ from rest_framework.request import Request
 from rest_framework.views import APIView
 
 from apps.applications.models import Application
-from apps.recruitments.models import Recruitment
 from apps.users.models import User
 
 
 class IsApplicantOrRecruiter(BasePermission):
-    """
-    지원자 본인 또는 공고 작성자만 접근 가능
-    """
-
+    # 지원자 본인 또는 공고 작성자만 접근 가능
     def has_object_permission(
         self,
         request: Request,

--- a/apps/applications/services/application_status_services.py
+++ b/apps/applications/services/application_status_services.py
@@ -1,0 +1,56 @@
+# apps/applications/applications_status_services.py
+
+from django.core.exceptions import ValidationError
+from django.db import transaction
+from rest_framework.exceptions import NotFound
+
+from apps.applications.models import Application
+from apps.studies.models import StudyGroup
+
+
+class ApplicationStatusService:
+    """
+    지원서 상태 변경 관련 서비스
+    - 승인 / 거절 로직 담당
+    """
+
+    @staticmethod
+    def get_application(application_id: int) -> Application:
+        try:
+            return Application.objects.select_related("user", "recruitment__author", "recruitment__study_group").get(
+                id=application_id
+            )
+        except Application.DoesNotExist:
+            raise NotFound("해당 지원 내역을 찾을 수 없습니다.")
+
+    @staticmethod
+    def approve(application: Application) -> Application:
+        if application.status != Application.ApplicationStatus.PENDING:
+            raise ValidationError("이미 처리된 지원서입니다.")
+
+        if not application.recruitment:
+            raise ValidationError("지원서에 연결된 공고가 없습니다.")
+
+        with transaction.atomic():
+            study_group = StudyGroup.objects.select_for_update().get(id=application.recruitment.study_group.id)
+            expected_headcount = application.recruitment.expected_headcount
+
+            if study_group.members.count() >= expected_headcount:
+                raise ValidationError("스터디 모집 인원이 모두 찼습니다. 승인할 수 없습니다.")
+
+            application.status = Application.ApplicationStatus.ACCEPTED
+            application.save()
+            study_group.members.add(application.user)
+
+        return application
+
+    @staticmethod
+    def reject(application: Application) -> Application:
+        if application.status != Application.ApplicationStatus.PENDING:
+            raise ValidationError("이미 처리된 지원서입니다.")
+
+        with transaction.atomic():
+            application.status = Application.ApplicationStatus.REJECTED
+            application.save()
+
+        return application

--- a/apps/applications/tests/test_application_detail.py
+++ b/apps/applications/tests/test_application_detail.py
@@ -125,3 +125,56 @@ class ApplicationDetailAPITest(APITestCase):
         non_existent_url = reverse("application-detail", kwargs={"application_id": 9999})
         response = self.client.get(non_existent_url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    # 승인
+
+    def test_success_author_can_approve_pending_application(self) -> None:
+        url = reverse("application-approve", kwargs={"application_id": self.application.id})
+        self.client.force_authenticate(user=self.author)
+        response = self.client.patch(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.application.refresh_from_db()
+        self.assertEqual(self.application.status, Application.ApplicationStatus.ACCEPTED)
+        self.assertIn(self.application.user, self.study_group.members.all())
+
+    def test_fail_author_can_approve_already_appproved(self) -> None:
+        self.application.status = Application.ApplicationStatus.ACCEPTED
+        self.application.save()
+
+        url = reverse("application-approve", kwargs={"application_id": self.application.id})
+        self.client.force_authenticate(user=self.author)
+        response = self.client.patch(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_fail_other_user_cannot_approve(self) -> None:
+        url = reverse("application-approve", kwargs={"application_id": self.application.id})
+        self.client.force_authenticate(user=self.other)
+        response = self.client.patch(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # 거절
+
+    def test_success_author_can_reject_pending_application(self) -> None:
+        url = reverse("application-reject", kwargs={"application_id": self.application.id})
+        self.client.force_authenticate(user=self.author)
+        response = self.client.patch(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        self.application.refresh_from_db()
+        self.assertEqual(self.application.status, Application.ApplicationStatus.REJECTED)
+
+    def test_fail_author_cannot_reject_already_rejected(self) -> None:
+        self.application.status = Application.ApplicationStatus.REJECTED
+        self.application.save()
+
+        url = reverse("application-reject", kwargs={"application_id": self.application.id})
+        self.client.force_authenticate(user=self.author)
+        response = self.client.patch(url)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_fail_other_user_cannot_reject(self) -> None:
+        url = reverse("application-reject", kwargs={"application_id": self.application.id})
+        self.client.force_authenticate(user=self.other)
+        response = self.client.patch(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/apps/applications/urls/applications_urls.py
+++ b/apps/applications/urls/applications_urls.py
@@ -1,7 +1,13 @@
 from django.urls import path
 
-from apps.applications.views.application_detail_views import ApplicationDetailView
+from apps.applications.views.application_detail_views import (
+    ApplicationApproveView,
+    ApplicationDetailView,
+    ApplicationRejectView,
+)
 
 urlpatterns = [
     path("/<int:application_id>", ApplicationDetailView.as_view(), name="application-detail"),
+    path("/<int:application_id>/approve", ApplicationApproveView.as_view(), name="application-approve"),
+    path("/<int:application_id>/reject", ApplicationRejectView.as_view(), name="application-reject"),
 ]

--- a/apps/applications/views/application_detail_views.py
+++ b/apps/applications/views/application_detail_views.py
@@ -16,11 +16,19 @@ from apps.applications.serializers.application_detail_serializers import (
 from apps.applications.services.application_status_services import (
     ApplicationStatusService,
 )
+from drf_spectacular.utils import extend_schema, OpenApiResponse
 
 
 class ApplicationDetailView(APIView):
     permission_classes = [IsApplicantOrRecruiter]
-
+    @extend_schema(
+        responses={
+            200: ApplicationDetailSerializer,
+            403: OpenApiResponse(description="권한 없음"),
+            404: OpenApiResponse(description="지원서 없음"),
+            500: OpenApiResponse(description="서버 에러"),
+        },
+    )
     def get(self, request: Request, application_id: int) -> Response:
         try:
             try:
@@ -38,6 +46,16 @@ class ApplicationDetailView(APIView):
         serializer = ApplicationDetailSerializer(application)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+@extend_schema(
+    summary="지원서 승인",
+    responses={
+        200: ApplicationDetailSerializer,
+        400: OpenApiResponse(description="잘못된 요청"),
+        403: OpenApiResponse(description="권한 없음"),
+        404: OpenApiResponse(description="지원서 없음"),
+        500: OpenApiResponse(description="서버 에러"),
+    },
+)
 
 class ApplicationStatusBaseView(APIView):
     permission_classes = [IsRecruiterOnly]
@@ -70,10 +88,28 @@ class ApplicationStatusBaseView(APIView):
         serializer = ApplicationDetailSerializer(application)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
-
+@extend_schema(
+    summary="지원서 승인",
+    responses={
+        200: ApplicationDetailSerializer,
+        400: OpenApiResponse(description="잘못된 요청"),
+        403: OpenApiResponse(description="권한 없음"),
+        404: OpenApiResponse(description="지원서 없음"),
+        500: OpenApiResponse(description="서버 에러"),
+    },
+)
 class ApplicationApproveView(ApplicationStatusBaseView):
     action = "approve"
 
-
+@extend_schema(
+    summary="지원서 거절",
+    responses={
+        200: ApplicationDetailSerializer,
+        400: OpenApiResponse(description="잘못된 요청"),
+        403: OpenApiResponse(description="권한 없음"),
+        404: OpenApiResponse(description="지원서 없음"),
+        500: OpenApiResponse(description="서버 에러"),
+    },
+)
 class ApplicationRejectView(ApplicationStatusBaseView):
     action = "reject"

--- a/apps/applications/views/application_detail_views.py
+++ b/apps/applications/views/application_detail_views.py
@@ -39,15 +39,21 @@ class ApplicationDetailView(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
-class ApplicationApproveView(APIView):
+class ApplicationStatusBaseView(APIView):
     permission_classes = [IsRecruiterOnly]
+    action: str = ""
 
     def patch(self, request: Request, application_id: int) -> Response:
         try:
             application = ApplicationStatusService.get_application(application_id)
             self.check_object_permissions(request, application)
 
-            application = ApplicationStatusService.approve(application)
+            if self.action == "approve":
+                application = ApplicationStatusService.approve(application)
+            elif self.action == "reject":
+                application = ApplicationStatusService.reject(application)
+            else:
+                raise ValidationError("Invalid action")
 
         except NotFound as e:
             return Response({"detail": str(e)}, status=status.HTTP_404_NOT_FOUND)
@@ -65,27 +71,9 @@ class ApplicationApproveView(APIView):
         return Response(serializer.data, status=status.HTTP_200_OK)
 
 
-class ApplicationRejectView(APIView):
-    permission_classes = [IsRecruiterOnly]
+class ApplicationApproveView(ApplicationStatusBaseView):
+    action = "approve"
 
-    def patch(self, request: Request, application_id: int) -> Response:
-        try:
-            application = ApplicationStatusService.get_application(application_id)
-            self.check_object_permissions(request, application)
 
-            application = ApplicationStatusService.reject(application)
-
-        except NotFound as e:
-            return Response({"detail": str(e)}, status=status.HTTP_404_NOT_FOUND)
-        except PermissionDenied as e:
-            return Response({"detail": str(e)}, status=status.HTTP_403_FORBIDDEN)
-        except ValidationError as e:
-            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
-        except Exception as e:
-            return Response(
-                {"detail": f"처리 중 오류가 발생했습니다: {str(e)}"},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            )
-
-        serializer = ApplicationDetailSerializer(application)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+class ApplicationRejectView(ApplicationStatusBaseView):
+    action = "reject"

--- a/apps/applications/views/application_detail_views.py
+++ b/apps/applications/views/application_detail_views.py
@@ -1,14 +1,20 @@
-from django.core.exceptions import PermissionDenied
-from rest_framework import permissions, status
-from rest_framework.exceptions import NotFound
+from django.core.exceptions import ValidationError
+from rest_framework import status
+from rest_framework.exceptions import NotFound, PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.applications.applications_permissions import IsApplicantOrRecruiter
+from apps.applications.applications_permissions import (
+    IsApplicantOrRecruiter,
+    IsRecruiterOnly,
+)
 from apps.applications.models import Application
 from apps.applications.serializers.application_detail_serializers import (
     ApplicationDetailSerializer,
+)
+from apps.applications.services.application_status_services import (
+    ApplicationStatusService,
 )
 
 
@@ -28,6 +34,58 @@ class ApplicationDetailView(APIView):
             return Response({"detail": str(e)}, status=status.HTTP_404_NOT_FOUND)
         except PermissionDenied as e:
             return Response({"detail": str(e)}, status=status.HTTP_403_FORBIDDEN)
+
+        serializer = ApplicationDetailSerializer(application)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class ApplicationApproveView(APIView):
+    permission_classes = [IsRecruiterOnly]
+
+    def patch(self, request: Request, application_id: int) -> Response:
+        try:
+            application = ApplicationStatusService.get_application(application_id)
+            self.check_object_permissions(request, application)
+
+            application = ApplicationStatusService.approve(application)
+
+        except NotFound as e:
+            return Response({"detail": str(e)}, status=status.HTTP_404_NOT_FOUND)
+        except PermissionDenied as e:
+            return Response({"detail": str(e)}, status=status.HTTP_403_FORBIDDEN)
+        except ValidationError as e:
+            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        except Exception as e:
+            return Response(
+                {"detail": f"처리 중 오류가 발생했습니다: {str(e)}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+        serializer = ApplicationDetailSerializer(application)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class ApplicationRejectView(APIView):
+    permission_classes = [IsRecruiterOnly]
+
+    def patch(self, request: Request, application_id: int) -> Response:
+        try:
+            application = ApplicationStatusService.get_application(application_id)
+            self.check_object_permissions(request, application)
+
+            application = ApplicationStatusService.reject(application)
+
+        except NotFound as e:
+            return Response({"detail": str(e)}, status=status.HTTP_404_NOT_FOUND)
+        except PermissionDenied as e:
+            return Response({"detail": str(e)}, status=status.HTTP_403_FORBIDDEN)
+        except ValidationError as e:
+            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        except Exception as e:
+            return Response(
+                {"detail": f"처리 중 오류가 발생했습니다: {str(e)}"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
 
         serializer = ApplicationDetailSerializer(application)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/apps/applications/views/application_detail_views.py
+++ b/apps/applications/views/application_detail_views.py
@@ -1,4 +1,5 @@
 from django.core.exceptions import ValidationError
+from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
 from rest_framework.exceptions import NotFound, PermissionDenied
 from rest_framework.request import Request
@@ -16,11 +17,11 @@ from apps.applications.serializers.application_detail_serializers import (
 from apps.applications.services.application_status_services import (
     ApplicationStatusService,
 )
-from drf_spectacular.utils import extend_schema, OpenApiResponse
 
 
 class ApplicationDetailView(APIView):
     permission_classes = [IsApplicantOrRecruiter]
+
     @extend_schema(
         responses={
             200: ApplicationDetailSerializer,
@@ -46,6 +47,7 @@ class ApplicationDetailView(APIView):
         serializer = ApplicationDetailSerializer(application)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+
 @extend_schema(
     summary="지원서 승인",
     responses={
@@ -56,7 +58,6 @@ class ApplicationDetailView(APIView):
         500: OpenApiResponse(description="서버 에러"),
     },
 )
-
 class ApplicationStatusBaseView(APIView):
     permission_classes = [IsRecruiterOnly]
     action: str = ""
@@ -88,6 +89,7 @@ class ApplicationStatusBaseView(APIView):
         serializer = ApplicationDetailSerializer(application)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+
 @extend_schema(
     summary="지원서 승인",
     responses={
@@ -100,6 +102,7 @@ class ApplicationStatusBaseView(APIView):
 )
 class ApplicationApproveView(ApplicationStatusBaseView):
     action = "approve"
+
 
 @extend_schema(
     summary="지원서 거절",


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #188 
- 작업 요약: 특정 공고에 지원한 신청서(지원서) 내역들을 승인 혹은 거절할 수 있는 기능 및 api입니다.

## 📄 상세 내용
- [1] 이미 승인되거나 거절된 항목에 대해서는 승인할 수 없어야 합니다.
- [2] 공고 모집 인원 수 만큼 이미 모집이 완료된 경우, 승인할 수 없습니다.
- [3] 승인 처리 즉시 스터디 그룹의 멤버로 등록되어야 하며, 멤버 등록 시 스터디 그룹의 정원을 초과 등록할 수 없습니다.

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
