### PR TITLE
스터디 그룹 리더 위임 API

### DIFF
--- a/apps/studies/serializers/study_group.py
+++ b/apps/studies/serializers/study_group.py
@@ -120,3 +120,11 @@ class StudyGroupCreateUpdateSerializer(serializers.ModelSerializer[StudyGroup]):
         ret = super().to_representation(instance)
         ret["lectures"] = list(instance.lectures.values_list("id", flat=True))
         return ret
+
+
+class StudyGroupLeaderDelegateSerializer(serializers.Serializer[Any]):
+    """
+    스터디 그룹 리더 위임 Serializer
+    """
+
+    new_leader_id = serializers.UUIDField()

--- a/apps/studies/tests/test_leader_delegate.py
+++ b/apps/studies/tests/test_leader_delegate.py
@@ -1,0 +1,99 @@
+import logging
+from datetime import datetime
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.core.tests.mixins.test_user_mixins import TestUserMixin
+from apps.lectures.models import Lecture
+from apps.lectures.models.crawled_lectures import DifficultyChoices, PlatformChoices
+from apps.studies.models import GroupMember, StudyGroup
+from apps.studies.serializers.study_group import StudyGroupCreateUpdateSerializer
+
+logger = logging.getLogger(__name__)
+
+
+class LeaderDelegateTests(APITestCase, TestUserMixin):
+    def setUp(self) -> None:
+        """
+        테스트를 위해 유저 생성 및 스터디 그룹 생성
+        """
+        self.leader = self._create_test_user()
+        self.newleader = self._create_test_user(
+            email="kimshineday@test.com", nickname="김빛날", phone_number="01098765432"
+        )
+        self.test_user = self._create_test_user(
+            email="testuser@test.com", nickname="테스트", phone_number="01000001111"
+        )
+        self.lecture = Lecture.objects.create(
+            title="test lecture",
+            instructor="김인직",
+            average_rating=4.23,
+            duration=20,
+            difficulty=DifficultyChoices.NORMAL,
+            description="testtest",
+            platform=PlatformChoices.INFLEARN,
+            original_price=40000,
+            discount_price=32000,
+            url_link="https://ozcoding.site/lectures/1",
+        )
+        self.data = {
+            "name": "스터디 그룹 리더 위임 테스트",
+            "introduction": "기본 데이터 생성",
+            "max_headcount": 3,
+            "start_at": datetime(2025, 10, 15),
+            "end_at": datetime(2025, 10, 30),
+            "lectures": [self.lecture.id],
+        }
+        self.serializer = StudyGroupCreateUpdateSerializer(data=self.data)
+        self.assertTrue(self.serializer.is_valid(raise_exception=True))
+        self.study_group = self.serializer.save(user=self.leader)
+        self.study_group_member = GroupMember.objects.create(
+            user=self.newleader, study_group=StudyGroup.objects.get(uuid=self.study_group.uuid)
+        )
+        # API
+        self.url = reverse("leader_delegate", kwargs={"group_uuid": self.study_group.uuid})
+
+    def test_delegate_fail_1(self) -> None:
+        """
+        리더 권한이 없는데 요청했을 경우.
+        """
+        self.client.force_authenticate(user=self.newleader)  # 스터디 그룹원
+
+        self.new_leader_data = {"new_leader_id": self.newleader.uuid}
+        response = self.client.post(self.url, data=self.new_leader_data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)  # 권한 X
+        new_leader = GroupMember.objects.get(user=self.newleader)
+        previous_leader = GroupMember.objects.get(user=self.leader)
+        # 데이터 변환 값 X
+        self.assertEqual(new_leader.is_leader, False)
+        self.assertEqual(previous_leader.is_leader, True)
+        logger.debug(response.data)
+
+    def test_delegate_fail_2(self) -> None:
+        """
+        스터디 그룹원이 아닌 사람에게 리더 위임을 할 경우.
+        """
+        self.client.force_authenticate(user=self.leader)  # 스터디 그룹 리더
+        self.new_leader_data = {"new_leader_id": self.test_user.uuid}  # 그룹원이 아닌 유저를 지정
+        response = self.client.post(self.url, data=self.new_leader_data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        previous_leader = GroupMember.objects.get(user=self.leader)
+        self.assertEqual(previous_leader.is_leader, True)  # 기존 리더 권한 유지
+        logger.debug(response.data)
+
+    def test_delegate_success(self) -> None:
+        """
+        성공 케이스
+        """
+        self.client.force_authenticate(user=self.leader)  # 스터디 그룹 리더
+
+        self.new_leader_data = {"new_leader_id": self.newleader.uuid}
+        response = self.client.post(self.url, data=self.new_leader_data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        new_leader = GroupMember.objects.get(study_group=self.study_group, user=self.newleader)
+        previous_leader = GroupMember.objects.get(study_group=self.study_group, user=self.leader)
+        # 데이터 변경
+        self.assertEqual(new_leader.is_leader, True)
+        self.assertEqual(previous_leader.is_leader, False)

--- a/apps/studies/urls/study_group.py
+++ b/apps/studies/urls/study_group.py
@@ -1,9 +1,11 @@
 from django.urls import path
 
+from apps.studies.views.leader_delegate_view import StudyGroupLeaderDelegateView
 from apps.studies.views.study_group_create_view import CreateStudyGroupView
 from apps.studies.views.study_group_update_view import UpdateStudyGroupView
 
 urlpatterns = [
     path("", CreateStudyGroupView.as_view(), name="create_study_group"),
     path("/<uuid:group_uuid>", UpdateStudyGroupView.as_view(), name="update_study_group"),
+    path("/<uuid:group_uuid>/delegate", StudyGroupLeaderDelegateView.as_view(), name="leader_delegate"),
 ]

--- a/apps/studies/views/leader_delegate_view.py
+++ b/apps/studies/views/leader_delegate_view.py
@@ -1,3 +1,4 @@
+from typing import cast
 from uuid import UUID
 
 from django.db import transaction
@@ -11,6 +12,7 @@ from rest_framework.views import APIView
 from apps.studies.models import GroupMember, StudyGroup
 from apps.studies.permissions import IsStudyGroupLeaderPermission
 from apps.studies.serializers.study_group import StudyGroupLeaderDelegateSerializer
+from apps.users.models import User
 
 
 class StudyGroupLeaderDelegateView(APIView):
@@ -44,11 +46,12 @@ class StudyGroupLeaderDelegateView(APIView):
             )
 
         with transaction.atomic():
+            user = cast(User, request.user)
             update = group.members.through.objects.filter(
                 study_group=group.id, user=new_leader.user, is_leader=False
             ).update(is_leader=True)
             if update:
-                group.members.through.objects.filter(study_group=group.id, is_leader=True).exclude(
-                    user=new_leader.user
-                ).update(is_leader=False)
+                group.members.through.objects.filter(study_group=group.id, user=user, is_leader=True).update(
+                    is_leader=False
+                )
             return Response(status=status.HTTP_200_OK)

--- a/apps/studies/views/leader_delegate_view.py
+++ b/apps/studies/views/leader_delegate_view.py
@@ -1,0 +1,54 @@
+from uuid import UUID
+
+from django.db import transaction
+from django.shortcuts import get_object_or_404
+from drf_spectacular.utils import extend_schema
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.studies.models import GroupMember, StudyGroup
+from apps.studies.permissions import IsStudyGroupLeaderPermission
+from apps.studies.serializers.study_group import StudyGroupLeaderDelegateSerializer
+
+
+class StudyGroupLeaderDelegateView(APIView):
+    """
+    스터디 그룹 리더는 스터디 그룹원에게 리더를 위임할 수 있다.
+    """
+
+    permission_classes = [IsStudyGroupLeaderPermission]
+
+    @extend_schema(
+        summary="스터디 그룹 리더 위임 API",
+        description="스터디 그룹 리더는 스터디 그룹원에게 리더를 위임할 수 있다.",
+        tags=["Study Group"],
+        request=StudyGroupLeaderDelegateSerializer,
+        responses=StudyGroupLeaderDelegateSerializer,
+    )
+    def post(self, request: Request, group_uuid: UUID) -> Response:
+        serializer = StudyGroupLeaderDelegateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        new_leader_id = serializer.validated_data["new_leader_id"]
+
+        group = get_object_or_404(StudyGroup, uuid=group_uuid)
+        self.check_object_permissions(request, group)
+
+        try:
+            new_leader = GroupMember.objects.get(study_group=group, user__uuid=new_leader_id)
+        except GroupMember.DoesNotExist:
+            return Response(
+                {"error": "스터디 그룹원이 아닌 유저에게 리더 권한 위임을 할 수 없습니다."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        with transaction.atomic():
+            update = group.members.through.objects.filter(
+                study_group=group.id, user=new_leader.user, is_leader=False
+            ).update(is_leader=True)
+            if update:
+                group.members.through.objects.filter(study_group=group.id, is_leader=True).exclude(
+                    user=new_leader.user
+                ).update(is_leader=False)
+            return Response(status=status.HTTP_200_OK)


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #183 
- 작업 요약: 스터디 그룹 리더 위임 API 개발

## 📄 상세 내용
- [ ] 스터디 그룹 리더 권한을 가지고 있는지 확인 로직
- [ ] 리더 위임을 하고자 하는 유저가 스터디 그룹원인지 확인 후 데이터 변경 (is_leader)
- [ ] View 코드 및 라우터 작성
- [ ] API 테스트 코드 작성

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
