### PR TITLE
🐛 fix: poetry dev group에 tblib 추가

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3550,6 +3550,18 @@ dev = ["build", "hatch"]
 doc = ["sphinx"]
 
 [[package]]
+name = "tblib"
+version = "3.1.0"
+description = "Traceback serialization library."
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "tblib-3.1.0-py3-none-any.whl", hash = "sha256:670bb4582578134b3d81a84afa1b016128b429f3d48e6cbbaecc9d15675e984e"},
+    {file = "tblib-3.1.0.tar.gz", hash = "sha256:06404c2c9f07f66fee2d7d6ad43accc46f9c3361714d9b8426e7f47e595cd652"},
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.2"
 description = "Retry code until it succeeds"
@@ -4144,4 +4156,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "b6cb52ce6a3b0c51bad75c160b48d9de01541f150ce1dc37a9821b7a1608815e"
+content-hash = "0ec009ccd05593f6d6211abe580eed79c876ebbb32420a169dd6afba4115df45"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ django-stubs = "^5.2.0"
 moto = "^5.1.12"
 celery-types = "^0.23.0"
 django-filter-stubs = "^0.1.3"
+tblib = "^3.1.0"
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]


### PR DESCRIPTION
Django의 parallel 테스트 실행 시 multiprocessing을 통해 프로세스 간 통신을 하는데, 테스트 실패 시 traceback 객체를 pickle하려고 시도함. 하지만 traceback 객체는 스택 프레임과 지역/전역 변수에 대한 참조를 포함하고 있어 pickle할 수 없기 때문에 이 오류가 발생하여 tblib 설치

## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: 어떤 작업을 했는지 간단하게 적어주세요.

## 📄 상세 내용
- [ ] 주요 변경 사항 1
- [ ] 주요 변경 사항 2
- [ ] 주요 변경 사항 3

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
