### PR TITLE
[Feature/withdrawal] View에 @extend_schema 추가

### DIFF
--- a/apps/users/views/withdrawals_view.py
+++ b/apps/users/views/withdrawals_view.py
@@ -116,5 +116,5 @@ class AccountRecoveryAPIView(APIView):
             return Response({"detail": str(e)}, status=status.HTTP_404_NOT_FOUND)
 
         except Exception:
-            logger.exception("계정 복구 처리 중 알 수 없는 오류 발생.") # 로그 기록
+            logger.exception("계정 복구 처리 중 알 수 없는 오류 발생.")  # 로그 기록
             return Response({"detail": "알 수 없는 오류가 발생했습니다."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/apps/users/views/withdrawals_view.py
+++ b/apps/users/views/withdrawals_view.py
@@ -1,5 +1,7 @@
 # apps/users/views/withdrawals_view.py
 
+import logging
+
 from drf_spectacular.utils import OpenApiExample, OpenApiResponse, extend_schema
 from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -24,6 +26,7 @@ from apps.users.services.withdrawals_service import create_withdrawal, recover_a
 from apps.users.utils.enums import VerificationPurpose
 
 email_service = EmailVerificationService()
+logger = logging.getLogger(__name__)
 
 
 class WithdrawalAPIView(APIView):
@@ -113,4 +116,5 @@ class AccountRecoveryAPIView(APIView):
             return Response({"detail": str(e)}, status=status.HTTP_404_NOT_FOUND)
 
         except Exception:
-            return Response({"detail": "알 수 없는 오류가 발생했습니다."}, status=status.HTTP_400_BAD_REQUEST)
+            logger.exception("계정 복구 처리 중 알 수 없는 오류 발생.")
+            return Response({"detail": "알 수 없는 오류가 발생했습니다."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/apps/users/views/withdrawals_view.py
+++ b/apps/users/views/withdrawals_view.py
@@ -116,5 +116,5 @@ class AccountRecoveryAPIView(APIView):
             return Response({"detail": str(e)}, status=status.HTTP_404_NOT_FOUND)
 
         except Exception:
-            logger.exception("계정 복구 처리 중 알 수 없는 오류 발생.")
+            logger.exception("계정 복구 처리 중 알 수 없는 오류 발생.") # 로그 기록
             return Response({"detail": "알 수 없는 오류가 발생했습니다."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #64 
- 작업 요약: view에 @extend_schema를 추가하여 API를 문서화.

## 📄 상세 내용
- [x] view에 @extend_schema 추가.
- [x] 사소하지만, 사용자가 시스템 에러 메시지를 볼 수 없도록 제거(관련 주석도 수정).

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다(버그 수정/기능에 대한 테스트).