### PR TITLE
[Feature/userinfo for pr] 사용자 정보 조회 및 수정 API

### DIFF
--- a/apps/users/serializers/user_info_serializer.py
+++ b/apps/users/serializers/user_info_serializer.py
@@ -7,12 +7,12 @@ from apps.users.models.user import User
 
 # 유저 정보 조회용
 class UserInfoSerializer(serializers.ModelSerializer[User]):
-    profile_img_url: serializers.URLField
-    email: serializers.EmailField
-    nickname: serializers.CharField
-    name: serializers.CharField
-    phone_number: serializers.CharField
-    birthday: serializers.DateField
+    profile_img_url = serializers.URLField()
+    email = serializers.EmailField()
+    nickname = serializers.CharField()
+    name = serializers.CharField()
+    phone_number = serializers.CharField()
+    birthday = serializers.DateField()
 
     class Meta:
         model = User
@@ -27,11 +27,14 @@ class UserInfoSerializer(serializers.ModelSerializer[User]):
 
 
 # 유저 정보 수정용
+# write_only: 서버에 전달만 하고 응답에는 포함하지 않음
 class UserInfoEditSerializer(serializers.ModelSerializer[User]):
-    profile_img: serializers.URLField
-    password: serializers.CharField
-    nickname: serializers.CharField
-    phone_number: serializers.CharField
+    profile_img_url = serializers.URLField(required=False)
+    password = serializers.CharField(required=False, write_only=True)
+    nickname = serializers.CharField(required=False)
+    phone_number = serializers.CharField(required=False)
+    is_phone_number_verified = serializers.BooleanField(required=False, write_only=True)
+    # True: 인증 완료 / False: 인증 미완료(인증 필요)
 
     class Meta:
         model = User
@@ -40,4 +43,12 @@ class UserInfoEditSerializer(serializers.ModelSerializer[User]):
             "password",
             "nickname",
             "phone_number",
+            "is_phone_number_verified",
         ]
+
+    # 비밀번호 암호화
+    def update(self, instance: User, validated_data: dict) -> User:
+        password = validated_data.pop("password", None)
+        if password:
+            instance.set_password(password)
+        return super().update(instance, validated_data)

--- a/apps/users/serializers/user_info_serializer.py
+++ b/apps/users/serializers/user_info_serializer.py
@@ -6,6 +6,7 @@ from rest_framework import serializers
 
 from apps.users.models.user import User
 from apps.users.services.phone_service import PhoneVerificationService
+from apps.users.utils.enums import VerificationPurpose
 
 
 # 유저 정보 직렬화
@@ -46,7 +47,8 @@ class UserInfoSerializer(serializers.ModelSerializer[User]):
 
         # 휴대폰 번호 변경 + 코드 검증
         if new_phone and code:
-            if not PhoneVerificationService.is_verified(new_phone, code):
+            purpose = VerificationPurpose.PROFILE_UPDATE
+            if not PhoneVerificationService.is_verified(new_phone, code, purpose):
                 raise serializers.ValidationError({"verification_code": "휴대폰 인증이 완료되지 않았습니다."})
 
         # 검증 완료 시 verification_code 제거

--- a/apps/users/serializers/user_info_serializer.py
+++ b/apps/users/serializers/user_info_serializer.py
@@ -26,17 +26,26 @@ class UserInfoSerializer(serializers.ModelSerializer[User]):
             "verification_code",
         ]
 
-    # 인증 번호 검증
+    # 인증 코드 검증
     def validate(self, attrs: Dict[str, Any]) -> Dict[str, Any]:
-        instance = self.instance
+        instance = getattr(self, 'instance', None) # self에 instance 속성이 없다면 None을 반환
         new_phone = attrs.get("phone_number") # attrs: 클라이언트가 전송한 변경 데이터들
         code = attrs.get("verification_code")
 
-        # 전화번호 변경이 없으면 인증 불필요
-        if isinstance(instance, User):
-            if not new_phone or instance.phone_number == new_phone:
-                attrs.pop("verification_code", None) # 대비용
-                return attrs
+        # 휴대폰 번호를 변경하지 않았다면 인증 코드 검증 불필요
+        #* 1) instance가 있고,
+        #* 2) new_phone이 없거나 new_phone이 기존 instance의 phone_number와 같다면,
+        #* 3) 인증 코드를 제거한 뒤 검증하지 않음
+        #* if instance and new_phone == instance.phone_number는 new_phone이 기존 instance의 phone_number와 같을 때만 실행됨
+        if instance and (not new_phone or instance.phone_number == new_phone):
+            attrs.pop("verification_code", None)  # 인증 코드 제거
+            return attrs
+
+        # 휴대폰 번호 중복 체크
+        if new_phone and User.objects.filter(phone_number=new_phone).exists():
+            raise serializers.ValidationError({
+                "phone_number": "이미 사용 중인 휴대폰 번호입니다."
+            })
 
         # 휴대폰 번호를 바꿨는데 인증 코드가 없다면 에러
         if new_phone and not code:
@@ -57,13 +66,9 @@ class UserInfoSerializer(serializers.ModelSerializer[User]):
     # 검증 후 실제 반영: setattr이 모든 필드를 덮어쓰기 때문에 허용 필드 관리 필수
     def update(self, instance: User, validated_data: Dict[str, Any]) -> User:
         validated_data.pop("verification_code", None)
+
         for attr, value in validated_data.items():
             setattr(instance, attr, value) # User 모델의 속성에 반영
 
         instance.save()
         return instance
-    
-        #? return super().create(validated_data)
-    
-    #? update_or_create()를 써도 괜찮으려나?
-    #? https://www.django-rest-framework.org/api-guide/serializers/#saving-instances

--- a/apps/users/serializers/user_info_serializer.py
+++ b/apps/users/serializers/user_info_serializer.py
@@ -1,18 +1,18 @@
 # apps/users/serializers/user_info_serializer.py
 
+from typing import Any, Dict
+
 from rest_framework import serializers
 
 from apps.users.models.user import User
+from apps.users.services.phone_service import PhoneVerificationService
 
 
-# 유저 정보 조회용
+# 유저 정보 직렬화
 class UserInfoSerializer(serializers.ModelSerializer[User]):
-    profile_img_url = serializers.URLField()
-    email = serializers.EmailField()
-    nickname = serializers.CharField()
-    name = serializers.CharField()
-    phone_number = serializers.CharField()
-    birthday = serializers.DateField()
+    # write_only = True: 응답에는 포함되지 않음
+    # required = False: 휴대폰 번호를 바꾸는 게 아니라면 필수로 요구하지는 않음
+    verification_code = serializers.CharField(write_only=True, required=False)
 
     class Meta:
         model = User
@@ -23,30 +23,47 @@ class UserInfoSerializer(serializers.ModelSerializer[User]):
             "name",
             "phone_number",
             "birthday",
+            "verification_code",
         ]
 
+    # 인증 번호 검증
+    def validate(self, attrs: Dict[str, Any]) -> Dict[str, Any]:
+        instance = self.instance
+        new_phone = attrs.get("phone_number") # attrs: 클라이언트가 전송한 변경 데이터들
+        code = attrs.get("verification_code")
 
-# 유저 정보 수정용
-class UserInfoEditSerializer(serializers.ModelSerializer[User]):
-    profile_img_url = serializers.URLField(required=False)
-    password = serializers.CharField(required=False, write_only=True)
-    nickname = serializers.CharField(required=False)
-    phone_number = serializers.CharField(required=False)
-    is_phone_number_verified = serializers.BooleanField(required=False, read_only=True)
+        # 전화번호 변경이 없으면 인증 불필요
+        if isinstance(instance, User):
+            if not new_phone or instance.phone_number == new_phone:
+                attrs.pop("verification_code", None) # 대비용
+                return attrs
 
-    class Meta:
-        model = User
-        fields = [
-            "profile_img_url",
-            "password",
-            "nickname",
-            "phone_number",
-            "is_phone_number_verified",
-        ]
+        # 휴대폰 번호를 바꿨는데 인증 코드가 없다면 에러
+        if new_phone and not code:
+            raise serializers.ValidationError({
+                "verification_code": "휴대폰 번호 변경 시 인증 코드가 필요합니다."
+            })
 
-    # 비밀번호 암호화
-    def update(self, instance: User, validated_data: dict) -> User:
-        password = validated_data.pop("password", None)
-        if password:
-            instance.set_password(password)
-        return super().update(instance, validated_data)
+        # 휴대폰 번호 변경 + 코드 검증
+        if new_phone and code:
+            if not PhoneVerificationService.is_verified(new_phone, code):
+                raise serializers.ValidationError({
+                    "verification_code": "휴대폰 인증이 완료되지 않았습니다."
+                })
+        # 검증 완료 시 verification_code 제거
+        attrs.pop("verification_code", None)
+        return attrs
+
+    # 검증 후 실제 반영: setattr이 모든 필드를 덮어쓰기 때문에 허용 필드 관리 필수
+    def update(self, instance: User, validated_data: Dict[str, Any]) -> User:
+        validated_data.pop("verification_code", None)
+        for attr, value in validated_data.items():
+            setattr(instance, attr, value) # User 모델의 속성에 반영
+
+        instance.save()
+        return instance
+    
+        #? return super().create(validated_data)
+    
+    #? update_or_create()를 써도 괜찮으려나?
+    #? https://www.django-rest-framework.org/api-guide/serializers/#saving-instances

--- a/apps/users/serializers/user_info_serializer.py
+++ b/apps/users/serializers/user_info_serializer.py
@@ -1,0 +1,43 @@
+# apps/users/serializers/user_info_serializer.py
+
+from rest_framework import serializers
+
+from apps.users.models.user import User
+
+
+# 유저 정보 조회용
+class UserInfoSerializer(serializers.ModelSerializer[User]):
+    profile_img_url: serializers.URLField
+    email: serializers.EmailField
+    nickname: serializers.CharField
+    name: serializers.CharField
+    phone_number: serializers.CharField
+    birthday: serializers.DateField
+
+    class Meta:
+        model = User
+        fields = [
+            "profile_img_url",
+            "email",
+            "nickname",
+            "name",
+            "phone_number",
+            "birthday",
+        ]
+
+
+# 유저 정보 수정용
+class UserInfoEditSerializer(serializers.ModelSerializer[User]):
+    profile_img: serializers.URLField
+    password: serializers.CharField
+    nickname: serializers.CharField
+    phone_number: serializers.CharField
+
+    class Meta:
+        model = User
+        fields = [
+            "profile_img_url",
+            "password",
+            "nickname",
+            "phone_number",
+        ]

--- a/apps/users/serializers/user_info_serializer.py
+++ b/apps/users/serializers/user_info_serializer.py
@@ -5,7 +5,6 @@ from typing import Any, Dict
 from rest_framework import serializers
 
 from apps.users.models.user import User
-from apps.users.services.phone_service import PhoneVerificationService
 
 
 # 유저 정보 직렬화
@@ -26,39 +25,8 @@ class UserInfoSerializer(serializers.ModelSerializer[User]):
             "verification_code",
         ]
 
-    # 인증 코드 검증
+    # 인증 코드 검증은 서비스에서 수행하므로 여기서는 제거만 처리
     def validate(self, attrs: Dict[str, Any]) -> Dict[str, Any]:
-        instance = getattr(self, 'instance', None) # self에 instance 속성이 없다면 None을 반환
-        new_phone = attrs.get("phone_number") # attrs: 클라이언트가 전송한 변경 데이터들
-        code = attrs.get("verification_code")
-
-        # 휴대폰 번호를 변경하지 않았다면 인증 코드 검증 불필요
-        #* 1) instance가 있고,
-        #* 2) new_phone이 없거나 new_phone이 기존 instance의 phone_number와 같다면,
-        #* 3) 인증 코드를 제거한 뒤 검증하지 않음
-        #* if instance and new_phone == instance.phone_number는 new_phone이 기존 instance의 phone_number와 같을 때만 실행됨
-        if instance and (not new_phone or instance.phone_number == new_phone):
-            attrs.pop("verification_code", None)  # 인증 코드 제거
-            return attrs
-
-        # 휴대폰 번호 중복 체크
-        if new_phone and User.objects.filter(phone_number=new_phone).exists():
-            raise serializers.ValidationError({
-                "phone_number": "이미 사용 중인 휴대폰 번호입니다."
-            })
-
-        # 휴대폰 번호를 바꿨는데 인증 코드가 없다면 에러
-        if new_phone and not code:
-            raise serializers.ValidationError({
-                "verification_code": "휴대폰 번호 변경 시 인증 코드가 필요합니다."
-            })
-
-        # 휴대폰 번호 변경 + 코드 검증
-        if new_phone and code:
-            if not PhoneVerificationService.is_verified(new_phone, code):
-                raise serializers.ValidationError({
-                    "verification_code": "휴대폰 인증이 완료되지 않았습니다."
-                })
         # 검증 완료 시 verification_code 제거
         attrs.pop("verification_code", None)
         return attrs

--- a/apps/users/serializers/user_info_serializer.py
+++ b/apps/users/serializers/user_info_serializer.py
@@ -27,14 +27,12 @@ class UserInfoSerializer(serializers.ModelSerializer[User]):
 
 
 # 유저 정보 수정용
-# write_only: 서버에 전달만 하고 응답에는 포함하지 않음
 class UserInfoEditSerializer(serializers.ModelSerializer[User]):
     profile_img_url = serializers.URLField(required=False)
     password = serializers.CharField(required=False, write_only=True)
     nickname = serializers.CharField(required=False)
     phone_number = serializers.CharField(required=False)
-    is_phone_number_verified = serializers.BooleanField(required=False, write_only=True)
-    # True: 인증 완료 / False: 인증 미완료(인증 필요)
+    is_phone_number_verified = serializers.BooleanField(required=False, read_only=True)
 
     class Meta:
         model = User

--- a/apps/users/serializers/user_info_serializer.py
+++ b/apps/users/serializers/user_info_serializer.py
@@ -5,13 +5,13 @@ from typing import Any, Dict
 from rest_framework import serializers
 
 from apps.users.models.user import User
+from apps.users.services.phone_service import PhoneVerificationService
 
 
 # 유저 정보 직렬화
 class UserInfoSerializer(serializers.ModelSerializer[User]):
     # write_only = True: 응답에는 포함되지 않음
-    # required = False: 휴대폰 번호를 바꾸는 게 아니라면 필수로 요구하지는 않음
-    verification_code = serializers.CharField(write_only=True, required=False)
+    verification_code = serializers.CharField(write_only=True)
 
     class Meta:
         model = User
@@ -25,8 +25,30 @@ class UserInfoSerializer(serializers.ModelSerializer[User]):
             "verification_code",
         ]
 
-    # 인증 코드 검증은 서비스에서 수행하므로 여기서는 제거만 처리
+    # 인증 코드 검증
     def validate(self, attrs: Dict[str, Any]) -> Dict[str, Any]:
+        instance = getattr(self, "instance", None)  # self에 instance 속성이 없다면 None을 반환
+        new_phone = attrs.get("phone_number")  # attrs: 클라이언트가 전송한 변경 데이터들
+        code = attrs.get("verification_code")
+
+        # 휴대폰 번호를 변경하지 않았다면 인증 코드 검증 불필요
+        # * 1) instance가 있고,
+        # * 2) new_phone이 없거나 new_phone이 기존 instance의 phone_number와 같다면,
+        # * 3) 인증 코드를 제거한 뒤 검증하지 않음
+        # * if instance and new_phone == instance.phone_number는 new_phone이 기존 instance의 phone_number와 같을 때만 실행됨
+        if instance and (not new_phone or instance.phone_number == new_phone):
+            attrs.pop("verification_code", None)  # 인증 코드 제거
+            return attrs
+
+        # 휴대폰 번호를 바꿨는데 인증 코드가 없다면 에러
+        if new_phone and not code:
+            raise serializers.ValidationError({"verification_code": "휴대폰 번호 변경 시 인증 코드가 필요합니다."})
+
+        # 휴대폰 번호 변경 + 코드 검증
+        if new_phone and code:
+            if not PhoneVerificationService.is_verified(new_phone, code):
+                raise serializers.ValidationError({"verification_code": "휴대폰 인증이 완료되지 않았습니다."})
+
         # 검증 완료 시 verification_code 제거
         attrs.pop("verification_code", None)
         return attrs
@@ -36,7 +58,7 @@ class UserInfoSerializer(serializers.ModelSerializer[User]):
         validated_data.pop("verification_code", None)
 
         for attr, value in validated_data.items():
-            setattr(instance, attr, value) # User 모델의 속성에 반영
+            setattr(instance, attr, value)  # User 모델의 속성에 반영
 
         instance.save()
         return instance

--- a/apps/users/serializers/withdrawals_serializer.py
+++ b/apps/users/serializers/withdrawals_serializer.py
@@ -34,3 +34,5 @@ class WithdrawalResponseSerializer(serializers.ModelSerializer[Withdrawals]):
 class AccountRecoverySerializer(serializers.Serializer[Withdrawals]):
     email = serializers.EmailField()
     verification_code = serializers.CharField()
+
+#TODO AdminWithdrawalSerializer(관리자 전용) 필요할 듯

--- a/apps/users/serializers/withdrawals_serializer.py
+++ b/apps/users/serializers/withdrawals_serializer.py
@@ -34,5 +34,3 @@ class WithdrawalResponseSerializer(serializers.ModelSerializer[Withdrawals]):
 class AccountRecoverySerializer(serializers.Serializer[Withdrawals]):
     email = serializers.EmailField()
     verification_code = serializers.CharField()
-
-#TODO AdminWithdrawalSerializer(관리자 전용) 필요할 듯

--- a/apps/users/services/user_info_service.py
+++ b/apps/users/services/user_info_service.py
@@ -11,6 +11,8 @@ from apps.users.serializers.user_info_serializer import (
     UserInfoSerializer,
 )
 
+#TODO phone_service.py 가져와서 써야 할 수도 있겠는데...
+#TODO 인증 번호 발송, 인증 번호 확인 등
 
 # 휴대폰 인증 관련 캐시 키 생성 함수(일관성 유지가 목적)
 def get_phone_verification_key(phone_number: str) -> str:

--- a/apps/users/services/user_info_service.py
+++ b/apps/users/services/user_info_service.py
@@ -1,1 +1,67 @@
-# apps/users/serializers/user_info_service.py
+# apps/users/services/user_info_service.py
+
+from typing import Any
+
+from django.core.cache import cache
+from rest_framework.exceptions import ValidationError
+
+from apps.users.models.user import User
+from apps.users.serializers.user_info_serializer import (
+    UserInfoEditSerializer,
+    UserInfoSerializer,
+)
+
+
+# 휴대폰 인증 관련 캐시 키 생성 함수(일관성 유지가 목적)
+def get_phone_verification_key(phone_number: str) -> str:
+    return f"phone_verification: {phone_number}"
+
+# 휴대폰 인증 서비스
+class PhoneVerificationService:
+    def __init__(self, phone_number: str, is_verified: bool):
+        self.phone_number = phone_number
+        self.is_verified = is_verified
+
+    def validate(self) -> None:
+        """
+        휴대폰 번호를 수정하려고 하면 인증이 완료되었는지를 확인함.
+        인증되지 않았다면 ValidationError 발생.
+        """
+        # is_verified가 False라면
+        if not self.is_verified:
+            raise ValidationError("휴대폰 인증이 필요합니다.")
+        
+        # 캐시에 인증된 번호가 없다면
+        cache_key = get_phone_verification_key(self.phone_number)
+        if not cache.get(cache_key):
+            raise ValidationError("인증된 휴대폰 번호가 아닙니다.")
+        
+    def clear_cache(self) -> None:
+        """
+        인증된 휴대폰 번호가 바뀌었다면, 휴대폰 번호를 업데이트하고 이전 번호를 삭제.
+        """
+        cache_key = get_phone_verification_key(self.phone_number)
+        cache.delete(cache_key)
+
+class UserInfoEditService:
+    def __init__(self, user: User):
+        self.user = user
+
+    def update_user_info(self, data: dict[str, Any]) -> User:
+        phone_number = data.get("phone_number")
+        is_verified = data.get("is_phone_number_verified", False)
+
+        # 휴대폰 번호가 있다면, 인증 검증
+        if phone_number:
+            PhoneVerificationService(phone_number, is_verified).validate()
+
+        # 사용자 정보 업데이트(serializer 처리)
+        serializer = UserInfoEditSerializer(instance=self.user, data=data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        updated_user = serializer.save()
+
+        # 휴대폰 번호가 실제로 변경되었다면, 인증했던 캐시 삭제
+        if phone_number and self.user.phone_number != phone_number:
+            PhoneVerificationService(phone_number, is_verified).clear_cache()
+
+        return updated_user

--- a/apps/users/services/user_info_service.py
+++ b/apps/users/services/user_info_service.py
@@ -3,34 +3,47 @@
 from typing import Any
 
 from rest_framework.exceptions import ValidationError
-from rest_framework.exceptions import AuthenticationFailed
 
 from apps.users.models.user import User
 from apps.users.serializers.user_info_serializer import UserInfoSerializer
-from apps.users.services.exceptions import PhoneVerificationCodeFailedError
-from apps.users.services.phone_service import TwilioAuthService #* 수정 예정
+from apps.users.services.phone_service import PhoneVerificationService
 
 
+# 사용자 정보 조회: 시리얼라이저로 직렬화
 class UserInfoService:
-    def __init__(self) -> None:
-        self.user: User | None = None
-    #TODO 조회 로직만 추가
+    def __init__(self, user: User) -> None:
+        self.user = user
+
+    def get_user_info(self) -> dict[str, Any]:
+        return UserInfoSerializer(self.user).data
+
 
 # 사용자 정보 수정(로그인한 사용자만 가능)
-#TODO phone_service.py를 호출해서 휴대폰 인증이 된 유저만 사용할 수 있도록
 class UserInfoEditService:
     def __init__(self, user: User):
         self.user = user
 
     def update_user_info(self, data: dict[str, Any]) -> User:
-        # 이하 data에서 추출하는 용도
-        phone_number = data.get("phone_number")
+        # 수정 가능한 필드를 한 줄로 추출
+        profile_img_url, nickname, password, phone_number, verification_code = (
+            data.get("profile_img_url"),
+            data.get("nickname"),
+            data.get("password"),
+            data.get("phone_number"),
+            data.get("verification_code"),
+        )
 
-        # 기존 휴대폰 번호와 동일한 번호로 변경하려고 할 때의 예외
-        if phone_number and self.user.phone_number == phone_number:
-            raise ValidationError("이전과 동일한 전화번호입니다.")
+        # 다른 회원이 이미 사용 중인 닉네임과 중복되는지 체크(자기 자신의 닉네임은 제외)
+        if nickname and User.objects.exclude(pk=self.user.pk).filter(nickname=nickname).exists():
+            raise ValidationError("이미 사용 중인 닉네임입니다.")
 
-        # 시리얼라이저를 통한 사용자 정보 업데이트
+        # 비밀번호 변경 시 암호화해서 저장
+        if password:
+            self.user.set_password(password)
+            self.user.save()  # 바뀐 비밀번호 저장
+            data.pop("password")  # 시리얼라이저에 넘기지 않음
+
+        # 시리얼라이저를 통한 사용자 정보 검증 후 저장(업데이트)
         serializer = UserInfoSerializer(instance=self.user, data=data, partial=True)
         serializer.is_valid(raise_exception=True)
         updated_user = serializer.save()

--- a/apps/users/services/user_info_service.py
+++ b/apps/users/services/user_info_service.py
@@ -6,7 +6,6 @@ from rest_framework.exceptions import ValidationError
 
 from apps.users.models.user import User
 from apps.users.serializers.user_info_serializer import UserInfoSerializer
-from apps.users.services.phone_service import PhoneVerificationService
 
 
 # 사용자 정보 조회: 시리얼라이저로 직렬화

--- a/apps/users/services/user_info_service.py
+++ b/apps/users/services/user_info_service.py
@@ -1,62 +1,38 @@
 # apps/users/services/user_info_service.py
 
 from typing import Any
+
 from rest_framework.exceptions import ValidationError
-from django.core.cache import cache
+from rest_framework.exceptions import AuthenticationFailed
+
 from apps.users.models.user import User
-from apps.users.serializers.user_info_serializer import (
-    UserInfoEditSerializer,
-    UserInfoSerializer,
-)
+from apps.users.serializers.user_info_serializer import UserInfoSerializer
+from apps.users.services.exceptions import PhoneVerificationCodeFailedError
+from apps.users.services.phone_service import TwilioAuthService #* 수정 예정
 
-#TODO 기존 번호와 동일한 번호로 변경하려고 하면 "동일한 번호입니다." 오류 생성.
-#? phone_service.py에서는 인증 번호를 생성하기만 하고, 그 번호가 맞는지는 여기서 체크하니까 굳이 phone_service.py를 import할 필요는 없는 걸까?
 
-# 휴대폰 인증 관련 캐시 키 최초 생성 함수
-#? 근데 내가 캐시 키를 왜 만들려고 했더라...?
-def get_phone_verification_key(phone_number: str) -> str:
-    return f"phone_verification: {phone_number}"
-
-# 인증이 완료된 휴대폰 번호를 캐시에 저장
-#? 이거 필요할까? 개인적으로는 의미를 분리하는 게 명확한 상태 기록에 도움이 될 듯싶다.
-def set_phone_verified(phone_number: str) -> None:
-    cache.set(get_phone_verification_key(phone_number), True)
-
-# 사용자 정보 조회
 class UserInfoService:
-    def __init__(self, user: User) -> None:
-        self.user = user
+    def __init__(self) -> None:
+        self.user: User | None = None
+    #TODO 조회 로직만 추가
 
-    def get_user_info(self) -> dict:
-        return UserInfoSerializer(self.user).data
-
-# 사용자 정보 수정
+# 사용자 정보 수정(로그인한 사용자만 가능)
+#TODO phone_service.py를 호출해서 휴대폰 인증이 된 유저만 사용할 수 있도록
 class UserInfoEditService:
     def __init__(self, user: User):
         self.user = user
 
     def update_user_info(self, data: dict[str, Any]) -> User:
+        # 이하 data에서 추출하는 용도
         phone_number = data.get("phone_number")
 
         # 기존 휴대폰 번호와 동일한 번호로 변경하려고 할 때의 예외
         if phone_number and self.user.phone_number == phone_number:
             raise ValidationError("이전과 동일한 전화번호입니다.")
 
-        # 휴대폰 번호가 (캐시에) 있다면, 인증 검증 / 휴대폰 번호가 (캐시에) 없다면, 예외 발생
-        if phone_number:
-            cache_key = get_phone_verification_key(phone_number)
-            if not cache.get(cache_key):
-                raise ValidationError("휴대폰 인증이 필요합니다.")
-
         # 시리얼라이저를 통한 사용자 정보 업데이트
-        serializer = UserInfoEditSerializer(instance=self.user, data=data, partial=True)
+        serializer = UserInfoSerializer(instance=self.user, data=data, partial=True)
         serializer.is_valid(raise_exception=True)
         updated_user = serializer.save()
-
-        # 휴대폰 번호가 실제로 변경되었다면, 인증했던 캐시 삭제 후 새로운 번호로 캐시 다시 저장
-        phone_number = serializer.validated_data.get("phone_number")
-        if phone_number and self.user.phone_number != phone_number:
-            cache.delete(get_phone_verification_key(self.user.phone_number))
-            cache.set(get_phone_verification_key(phone_number), True)
 
         return updated_user

--- a/apps/users/services/user_info_service.py
+++ b/apps/users/services/user_info_service.py
@@ -1,0 +1,1 @@
+# apps/users/serializers/user_info_service.py

--- a/apps/users/services/user_info_service.py
+++ b/apps/users/services/user_info_service.py
@@ -16,7 +16,15 @@ from apps.users.serializers.user_info_serializer import (
 def get_phone_verification_key(phone_number: str) -> str:
     return f"phone_verification: {phone_number}"
 
-# 사용자 정보 수정(조회는 view에서 처리)
+# 사용자 정보 조회
+class UserInfoService:
+    def __init__(self) -> None:
+        self.user = User
+
+    def get_user_info(self) -> dict:
+        return UserInfoSerializer(self.user).data
+
+# 사용자 정보 수정
 class UserInfoEditService:
     def __init__(self, user: User):
         self.user = user
@@ -30,8 +38,7 @@ class UserInfoEditService:
             if not cache.get(cache_key):
                 raise ValidationError("휴대폰 인증이 필요합니다.")
 
-
-        # 사용자 정보 업데이트(serializer 처리)
+        # 사용자 정보 업데이트(serializer가 처리)
         serializer = UserInfoEditSerializer(instance=self.user, data=data, partial=True)
         serializer.is_valid(raise_exception=True)
         updated_user = serializer.save()

--- a/apps/users/services/user_info_service.py
+++ b/apps/users/services/user_info_service.py
@@ -9,9 +9,11 @@ from apps.users.serializers.user_info_serializer import (
     UserInfoSerializer,
 )
 
+#TODO 기존 번호와 동일한 번호로 변경하려고 하면 "동일한 번호입니다." 오류 생성.
 #? phone_service.py에서는 인증 번호를 생성하기만 하고, 그 번호가 맞는지는 여기서 체크하니까 굳이 phone_service.py를 import할 필요는 없는 걸까?
 
-# 휴대폰 인증 관련 캐시 키 생성 함수
+# 휴대폰 인증 관련 캐시 키 최초 생성 함수
+#? 근데 내가 캐시 키를 왜 만들려고 했더라...?
 def get_phone_verification_key(phone_number: str) -> str:
     return f"phone_verification: {phone_number}"
 
@@ -36,8 +38,11 @@ class UserInfoEditService:
     def update_user_info(self, data: dict[str, Any]) -> User:
         phone_number = data.get("phone_number")
 
-        # 휴대폰 번호가 (캐시에) 있다면, 인증 검증
-        # 휴대폰 번호가 (캐시에) 없다면, 예외 발생
+        # 기존 휴대폰 번호와 동일한 번호로 변경하려고 할 때의 예외
+        if phone_number and self.user.phone_number == phone_number:
+            raise ValidationError("이전과 동일한 전화번호입니다.")
+
+        # 휴대폰 번호가 (캐시에) 있다면, 인증 검증 / 휴대폰 번호가 (캐시에) 없다면, 예외 발생
         if phone_number:
             cache_key = get_phone_verification_key(phone_number)
             if not cache.get(cache_key):
@@ -48,8 +53,10 @@ class UserInfoEditService:
         serializer.is_valid(raise_exception=True)
         updated_user = serializer.save()
 
-        # 휴대폰 번호가 실제로 변경되었다면, 인증했던 캐시 삭제
+        # 휴대폰 번호가 실제로 변경되었다면, 인증했던 캐시 삭제 후 새로운 번호로 캐시 다시 저장
+        phone_number = serializer.validated_data.get("phone_number")
         if phone_number and self.user.phone_number != phone_number:
-            cache.delete(get_phone_verification_key(phone_number))
+            cache.delete(get_phone_verification_key(self.user.phone_number))
+            cache.set(get_phone_verification_key(phone_number), True)
 
         return updated_user

--- a/apps/users/services/user_info_service.py
+++ b/apps/users/services/user_info_service.py
@@ -1,10 +1,8 @@
 # apps/users/services/user_info_service.py
 
 from typing import Any
-
-from django.core.cache import cache
 from rest_framework.exceptions import ValidationError
-
+from django.core.cache import cache
 from apps.users.models.user import User
 from apps.users.serializers.user_info_serializer import (
     UserInfoEditSerializer,
@@ -18,44 +16,20 @@ from apps.users.serializers.user_info_serializer import (
 def get_phone_verification_key(phone_number: str) -> str:
     return f"phone_verification: {phone_number}"
 
-# 휴대폰 인증 서비스
-class PhoneVerificationService:
-    def __init__(self, phone_number: str, is_verified: bool):
-        self.phone_number = phone_number
-        self.is_verified = is_verified
-
-    def validate(self) -> None:
-        """
-        휴대폰 번호를 수정하려고 하면 인증이 완료되었는지를 확인함.
-        인증되지 않았다면 ValidationError 발생.
-        """
-        # is_verified가 False라면
-        if not self.is_verified:
-            raise ValidationError("휴대폰 인증이 필요합니다.")
-        
-        # 캐시에 인증된 번호가 없다면
-        cache_key = get_phone_verification_key(self.phone_number)
-        if not cache.get(cache_key):
-            raise ValidationError("인증된 휴대폰 번호가 아닙니다.")
-        
-    def clear_cache(self) -> None:
-        """
-        인증된 휴대폰 번호가 바뀌었다면, 휴대폰 번호를 업데이트하고 이전 번호를 삭제.
-        """
-        cache_key = get_phone_verification_key(self.phone_number)
-        cache.delete(cache_key)
-
+# 사용자 정보 수정(조회는 view에서 처리)
 class UserInfoEditService:
     def __init__(self, user: User):
         self.user = user
 
     def update_user_info(self, data: dict[str, Any]) -> User:
         phone_number = data.get("phone_number")
-        is_verified = data.get("is_phone_number_verified", False)
 
         # 휴대폰 번호가 있다면, 인증 검증
         if phone_number:
-            PhoneVerificationService(phone_number, is_verified).validate()
+            cache_key = get_phone_verification_key(phone_number)
+            if not cache.get(cache_key):
+                raise ValidationError("휴대폰 인증이 필요합니다.")
+
 
         # 사용자 정보 업데이트(serializer 처리)
         serializer = UserInfoEditSerializer(instance=self.user, data=data, partial=True)
@@ -64,6 +38,6 @@ class UserInfoEditService:
 
         # 휴대폰 번호가 실제로 변경되었다면, 인증했던 캐시 삭제
         if phone_number and self.user.phone_number != phone_number:
-            PhoneVerificationService(phone_number, is_verified).clear_cache()
+            cache.delete(get_phone_verification_key(phone_number))
 
         return updated_user

--- a/apps/users/services/user_info_service.py
+++ b/apps/users/services/user_info_service.py
@@ -9,17 +9,21 @@ from apps.users.serializers.user_info_serializer import (
     UserInfoSerializer,
 )
 
-#TODO phone_service.py 가져와서 써야 할 수도 있겠는데...
-#TODO 인증 번호 발송, 인증 번호 확인 등
+#? phone_service.py에서는 인증 번호를 생성하기만 하고, 그 번호가 맞는지는 여기서 체크하니까 굳이 phone_service.py를 import할 필요는 없는 걸까?
 
-# 휴대폰 인증 관련 캐시 키 생성 함수(일관성 유지가 목적)
+# 휴대폰 인증 관련 캐시 키 생성 함수
 def get_phone_verification_key(phone_number: str) -> str:
     return f"phone_verification: {phone_number}"
 
+# 인증이 완료된 휴대폰 번호를 캐시에 저장
+#? 이거 필요할까? 개인적으로는 의미를 분리하는 게 명확한 상태 기록에 도움이 될 듯싶다.
+def set_phone_verified(phone_number: str) -> None:
+    cache.set(get_phone_verification_key(phone_number), True)
+
 # 사용자 정보 조회
 class UserInfoService:
-    def __init__(self) -> None:
-        self.user = User
+    def __init__(self, user: User) -> None:
+        self.user = user
 
     def get_user_info(self) -> dict:
         return UserInfoSerializer(self.user).data
@@ -32,13 +36,14 @@ class UserInfoEditService:
     def update_user_info(self, data: dict[str, Any]) -> User:
         phone_number = data.get("phone_number")
 
-        # 휴대폰 번호가 있다면, 인증 검증
+        # 휴대폰 번호가 (캐시에) 있다면, 인증 검증
+        # 휴대폰 번호가 (캐시에) 없다면, 예외 발생
         if phone_number:
             cache_key = get_phone_verification_key(phone_number)
             if not cache.get(cache_key):
                 raise ValidationError("휴대폰 인증이 필요합니다.")
 
-        # 사용자 정보 업데이트(serializer가 처리)
+        # 시리얼라이저를 통한 사용자 정보 업데이트
         serializer = UserInfoEditSerializer(instance=self.user, data=data, partial=True)
         serializer.is_valid(raise_exception=True)
         updated_user = serializer.save()

--- a/apps/users/tests/test_user_info.py
+++ b/apps/users/tests/test_user_info.py
@@ -8,7 +8,8 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 from rest_framework_simplejwt.tokens import RefreshToken
 
-from apps.users.models import User
+from apps.users.models.user import User
+from apps.users.utils.enums import VerificationPurpose
 
 
 class UserInfoTest(APITestCase):
@@ -43,13 +44,12 @@ class UserInfoTest(APITestCase):
         self.login()  # 로그인
         response = self.client.get(self.url)  # 정보 조회 요청
         self.assertEqual(response.status_code, status.HTTP_200_OK)  # 조회 성공
-        print("1) 로그인 후 조회 완료:", response.data)  # 조회한 데이터 체크
 
     # 실패: 비로그인 상태로 조회 시도(401)
     def test_get_user_info_unauthorized(self) -> None:
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-        self.assertTrue("detail" in response.data or "error" in response.data, print(response.data))
+        self.assertTrue("detail" in response.data or "error" in response.data)
 
 
 class UserInfoEditTest(APITestCase):
@@ -80,9 +80,8 @@ class UserInfoEditTest(APITestCase):
         self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {refresh.access_token}")
 
     # 성공: 수정 완료(200)
-    @patch(
-        "apps.users.services.user_info_service.PhoneVerificationService.is_verified", return_value=True
-    )  # 실제로 PhoneVerificationService를 호출하지 않고, mock으로 대체
+    @patch("apps.users.services.phone_service.PhoneVerificationService.is_verified", return_value=True)
+    # 실제로 PhoneVerificationService를 호출하지 않고, mock으로 대체
     def test_patch_user_info_success(self, mock_is_verified: Mock) -> None:
         self.login()
         data = {
@@ -91,15 +90,13 @@ class UserInfoEditTest(APITestCase):
             "phone_number": "01098798789",
             "verification_code": "123456",
         }
-        print("2-1) 수정 이전의 원본 데이터: ", data)
 
         response = self.client.patch(self.edit_url, data, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        print("2-2) 수정 이후의 바뀐 데이터: ", response.data)
 
         mock_is_verified.assert_called_once_with(
-            data["phone_number"], data["verification_code"]
+            data["phone_number"], data["verification_code"], VerificationPurpose.PROFILE_UPDATE
         )  # mock 함수가 정확히 1회만 호출되었고, 인자가 기댓값과 일치하는지 확인
 
     # 실패: 비로그인 상태로 수정 시도(401)
@@ -117,9 +114,8 @@ class UserInfoEditTest(APITestCase):
         self.assertIn("detail", response.data)
 
     # 실패: 인증 코드 누락(401) - "인증이 필요한데 하지 않았다"
-    @patch(
-        "apps.users.services.user_info_service.PhoneVerificationService.is_verified", return_value=False
-    )  # 실제로 PhoneVerificationService를 호출하지 않고, mock으로 대체
+    @patch("apps.users.services.phone_service.PhoneVerificationService.is_verified", return_value=False)
+    # 실제로 PhoneVerificationService를 호출하지 않고, mock으로 대체
     def test_patch_user_info_without_verification_code(self, mock_is_verified: Mock) -> None:
         self.login()
         data = {"phone_number": "01011112222"}
@@ -129,9 +125,8 @@ class UserInfoEditTest(APITestCase):
         mock_is_verified.assert_not_called()  # 호출되지 않았어야 함
 
     # 실패: 잘못된 인증 코드(400)
-    @patch(
-        "apps.users.services.user_info_service.PhoneVerificationService.is_verified", return_value=False
-    )  # 실제로 PhoneVerificationService를 호출하지 않고, mock으로 대체
+    @patch("apps.users.services.phone_service.PhoneVerificationService.is_verified", return_value=False)
+    # 실제로 PhoneVerificationService를 호출하지 않고, mock으로 대체
     def test_patch_user_info_invalid_verification_code(self, mock_is_verified: Mock) -> None:
         self.login()
         data = {
@@ -142,7 +137,7 @@ class UserInfoEditTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("detail", response.data)
         mock_is_verified.assert_called_once_with(
-            data["phone_number"], data["verification_code"]
+            data["phone_number"], data["verification_code"], VerificationPurpose.PROFILE_UPDATE
         )  # mock 함수가 정확히 1회만 호출되었고, 인자가 기댓값과 일치하는지 확인
 
     # 실패: 중복 닉네임(400)

--- a/apps/users/tests/test_user_info.py
+++ b/apps/users/tests/test_user_info.py
@@ -1,10 +1,11 @@
 # tests/users/test_user_info_view.py
 
-from rest_framework.test import APITestCase
+from datetime import date
+
+from django.core.cache import cache
 from django.urls import reverse
 from rest_framework import status
-from django.core.cache import cache
-from datetime import date
+from rest_framework.test import APITestCase
 
 from apps.users.models import User
 
@@ -61,5 +62,9 @@ class UserInfoViewTests(APITestCase):
         pass
 
     # 실패: 이미 등록된 전화번호(400/409)
-    def test_patch_user_info_phone_number_duplicate(self):
+    def test_patch_user_info_already_registered_phone_number(self):
+        pass
+
+    # 실패: 중복 닉네임(400/409)
+    def test_patch_user_info_already_exists_nickname(self):
         pass

--- a/apps/users/tests/test_user_info.py
+++ b/apps/users/tests/test_user_info.py
@@ -1,19 +1,24 @@
 # tests/users/test_user_info_view.py
 
 from datetime import date
+from unittest.mock import Mock, patch
 
-from django.core.cache import cache
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APITestCase
+from rest_framework_simplejwt.tokens import RefreshToken
 
 from apps.users.models import User
 
 
-class UserInfoViewTests(APITestCase):
+class UserInfoTest(APITestCase):
+    user: User
+    url: str
+    edit_url: str
+
     @classmethod
-    def setUpTestData(cls):
-        # 테스트용 사용자 생성
+    def setUpTestData(cls) -> None:
+        # 테스트용 기본 사용자 생성
         cls.user = User.objects.create_user(
             profile_img_url="http://example.com/profile.jpg",
             email="test@example.com",
@@ -22,49 +27,141 @@ class UserInfoViewTests(APITestCase):
             name="Imsocool",
             phone_number="01012345678",
             birthday=date(2001, 9, 22),
+            is_active=True,  # 계정 활성화 여부를 명시적으로 지정
         )
-        cls.url = reverse("user_info")
 
-    def setUp(self):
-        self.user = self.__class__.user
-        cache.clear() # 테스트마다 인증 캐시 초기화
+        cls.url = reverse("user_info")  # 조회용 URL
+        cls.edit_url = reverse("user_info_edit")  # 수정용 URL
 
-    # 성공: 조회 완료(200)
-    def test_get_user_info_success(self):
-        pass
+    # JWT 토큰을 생성하여 사용자를 로그인 상태로 설정
+    def login(self) -> None:
+        refresh = RefreshToken.for_user(self.user)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {refresh.access_token}")
+
+    # 성공: 로그인 후 조회 완료(200)
+    def test_get_user_info_success(self) -> None:
+        self.login()  # 로그인
+        response = self.client.get(self.url)  # 정보 조회 요청
+        self.assertEqual(response.status_code, status.HTTP_200_OK)  # 조회 성공
+        print("1) 로그인 후 조회 완료:", response.data)  # 조회한 데이터 체크
 
     # 실패: 비로그인 상태로 조회 시도(401)
-    def test_get_user_info_unauthorized(self):
-        pass
+    def test_get_user_info_unauthorized(self) -> None:
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertTrue("detail" in response.data or "error" in response.data, print(response.data))
+
+
+class UserInfoEditTest(APITestCase):
+    user: User
+    url: str
+    edit_url: str
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        # 테스트용 기본 사용자 생성
+        cls.user = User.objects.create_user(
+            profile_img_url="http://example.com/profile.jpg",
+            email="test@example.com",
+            password="securepassword123",
+            nickname="cooluser",
+            name="Imsocool",
+            phone_number="01012345678",
+            birthday=date(2001, 9, 22),
+            is_active=True,  # 계정 활성화 여부를 명시적으로 지정
+        )
+
+        cls.url = reverse("user_info")  # 조회용 URL
+        cls.edit_url = reverse("user_info_edit")  # 수정용 URL
+
+    # JWT 토큰을 생성하여 사용자를 로그인 상태로 설정
+    def login(self) -> None:
+        refresh = RefreshToken.for_user(self.user)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {refresh.access_token}")
 
     # 성공: 수정 완료(200)
-    def test_patch_user_info_success(self):
-        pass
-    
+    @patch(
+        "apps.users.services.user_info_service.PhoneVerificationService.is_verified", return_value=True
+    )  # 실제로 PhoneVerificationService를 호출하지 않고, mock으로 대체
+    def test_patch_user_info_success(self, mock_is_verified: Mock) -> None:
+        self.login()
+        data = {
+            "nickname": "newnicky",
+            "password": "newsecurepassword",
+            "phone_number": "01098798789",
+            "verification_code": "123456",
+        }
+        print("2-1) 수정 이전의 원본 데이터: ", data)
+
+        response = self.client.patch(self.edit_url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        print("2-2) 수정 이후의 바뀐 데이터: ", response.data)
+
+        mock_is_verified.assert_called_once_with(
+            data["phone_number"], data["verification_code"]
+        )  # mock 함수가 정확히 1회만 호출되었고, 인자가 기댓값과 일치하는지 확인
+
     # 실패: 비로그인 상태로 수정 시도(401)
-    def test_patch_user_info_unauthorized(self):
-        pass
+    def test_patch_user_info_unauthorized(self) -> None:
+        data = {"nickname": "newnicky"}
+        response = self.client.patch(self.edit_url, data)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     # 실패: 유효하지 않은 데이터(잘못된 필드 값 등)(400)
-    def test_patch_user_info_invalid_data(self):
-        pass
+    def test_patch_user_info_invalid_data(self) -> None:
+        self.login()
+        data = {"email": "invalid-email-format"}
+        response = self.client.patch(self.edit_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("detail", response.data)
 
-    # 실패: 필수 필드 누락(400) #? 필요할까?
-    def test_patch_user_info_missing_required_field(self):
-        pass
+    # 실패: 인증 코드 누락(401) - "인증이 필요한데 하지 않았다"
+    @patch(
+        "apps.users.services.user_info_service.PhoneVerificationService.is_verified", return_value=False
+    )  # 실제로 PhoneVerificationService를 호출하지 않고, mock으로 대체
+    def test_patch_user_info_without_verification_code(self, mock_is_verified: Mock) -> None:
+        self.login()
+        data = {"phone_number": "01011112222"}
+        response = self.client.patch(self.edit_url, data)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn("detail", response.data)
+        mock_is_verified.assert_not_called()  # 호출되지 않았어야 함
 
     # 실패: 잘못된 인증 코드(400)
-    def test_patch_user_info_invalid_verification_code(self):
-        pass
+    @patch(
+        "apps.users.services.user_info_service.PhoneVerificationService.is_verified", return_value=False
+    )  # 실제로 PhoneVerificationService를 호출하지 않고, mock으로 대체
+    def test_patch_user_info_invalid_verification_code(self, mock_is_verified: Mock) -> None:
+        self.login()
+        data = {
+            "phone_number": "01011112222",
+            "verification_code": "wrongcode",
+        }
+        response = self.client.patch(self.edit_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("detail", response.data)
+        mock_is_verified.assert_called_once_with(
+            data["phone_number"], data["verification_code"]
+        )  # mock 함수가 정확히 1회만 호출되었고, 인자가 기댓값과 일치하는지 확인
 
-    # 실패: 인증 코드 누락(400)
-    def test_patch_user_info_without_verification_code(self):
-        pass
+    # 실패: 중복 닉네임(400)
+    def test_patch_user_info_duplicate_nickname(self) -> None:
+        self.login()
+        # 다른 사용자 생성
+        User.objects.create_user(
+            profile_img_url="http://example.com/profile2.jpg",
+            email="test8@example.com",
+            password="securepassword128",
+            nickname="alreadyin",
+            name="realname",
+            phone_number="01010101010",
+            birthday=date(2001, 9, 25),
+            is_active=True,
+        )
 
-    # 실패: 이미 등록된 전화번호(400/409)
-    def test_patch_user_info_already_registered_phone_number(self):
-        pass
-
-    # 실패: 중복 닉네임(400/409)
-    def test_patch_user_info_already_exists_nickname(self):
-        pass
+        # 중복 닉네임
+        data = {"nickname": "alreadyin"}
+        response = self.client.patch(self.edit_url, data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("detail", response.data)

--- a/apps/users/tests/test_user_info.py
+++ b/apps/users/tests/test_user_info.py
@@ -1,0 +1,82 @@
+# tests/users/test_user_info_view.py
+
+from rest_framework.test import APITestCase
+from django.urls import reverse
+from rest_framework import status
+from django.core.cache import cache
+from datetime import date
+
+from apps.users.models import User
+from apps.users.services.user_info_service import  get_phone_verification_key
+
+
+class UserInfoViewTests(APITestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(
+            profile_img_url="http://example.com/profile.jpg",
+            email="test@example.com",
+            password="securepassword123", # 조회할 때 불러오지는 않음
+            nickname="cooluser",
+            name="Imsocool",
+            phone_number="01012345678",
+            birthday=date(2001, 9, 22),
+        )
+        cls.url = reverse("user_info")
+
+    # 로그인한 사용자가 정보 조회를 시도
+    # force_authenticate() 사용으로 강제 인증
+    def test_get_user_info_authenticated(self):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    # 로그인하지 않은 사용자가 정보 조회를 시도
+    def test_get_user_info_unauthenticated(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    # 로그인한 사용자의 정보 수정: 휴대폰 인증을 완료한 버전(성공 케이스)
+    def test_patch_user_info_success(self):
+        self.client.force_authenticate(user=self.user)
+
+        # 휴대폰 인증 캐시 설정
+        phone_number = "01099998888"
+        cache.set(get_phone_verification_key(phone_number), True)
+
+        # 변경할 데이터
+        data = {
+            "profile_img_url": "http://example.com/new_profile.jpg",
+            "password": "securepassword456",
+            "nickname": "newnicky",
+            "phone_number": phone_number,
+            "is_phone_number_verified": True,
+        }
+
+        response = self.client.patch(self.url, data, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        # 데이터가 제대로 변경됐는지 DB 체크
+        for key, check_data in data.items():
+            self.assertEqual(response.data[key], check_data)
+
+    # 로그인한 사용자의 정보 수정: 휴대폰 인증을 하지 않은 버전(실패 케이스)
+    def test_patch_user_info_without_verification(self):
+        self.client.force_authenticate(self.user)
+
+        data = {
+            "phone_number": "01011112222",
+            "is_phone_number_verified": False,
+        }
+
+        response = self.client.patch(self.url, data, content_type="application/json")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("휴대폰 인증이 필요합니다.", response.json()["detail"])
+
+    def test_patch_user_info_unauthenticated(self):
+        data = {
+            "nickname": "anonymous",
+        }
+
+        response = self.client.patch(self.url, data, content_type="application/json")
+        self.assertEqual(response.status_code, 401)

--- a/apps/users/tests/test_user_info.py
+++ b/apps/users/tests/test_user_info.py
@@ -7,16 +7,16 @@ from django.core.cache import cache
 from datetime import date
 
 from apps.users.models import User
-from apps.users.services.user_info_service import  get_phone_verification_key
 
 
 class UserInfoViewTests(APITestCase):
     @classmethod
     def setUpTestData(cls):
+        # 테스트용 사용자 생성
         cls.user = User.objects.create_user(
             profile_img_url="http://example.com/profile.jpg",
             email="test@example.com",
-            password="securepassword123", # 조회할 때 불러오지는 않음
+            password="securepassword123",
             nickname="cooluser",
             name="Imsocool",
             phone_number="01012345678",
@@ -24,59 +24,42 @@ class UserInfoViewTests(APITestCase):
         )
         cls.url = reverse("user_info")
 
-    # 로그인한 사용자가 정보 조회를 시도
-    # force_authenticate() 사용으로 강제 인증
-    def test_get_user_info_authenticated(self):
-        self.client.force_authenticate(user=self.user)
-        response = self.client.get(self.url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+    def setUp(self):
+        self.user = self.__class__.user
+        cache.clear() # 테스트마다 인증 캐시 초기화
 
-    # 로그인하지 않은 사용자가 정보 조회를 시도
-    def test_get_user_info_unauthenticated(self):
-        response = self.client.get(self.url)
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+    # 성공: 조회 완료(200)
+    def test_get_user_info_success(self):
+        pass
 
-    # 로그인한 사용자의 정보 수정: 휴대폰 인증을 완료한 버전(성공 케이스)
+    # 실패: 비로그인 상태로 조회 시도(401)
+    def test_get_user_info_unauthorized(self):
+        pass
+
+    # 성공: 수정 완료(200)
     def test_patch_user_info_success(self):
-        self.client.force_authenticate(user=self.user)
+        pass
+    
+    # 실패: 비로그인 상태로 수정 시도(401)
+    def test_patch_user_info_unauthorized(self):
+        pass
 
-        # 휴대폰 인증 캐시 설정
-        phone_number = "01099998888"
-        cache.set(get_phone_verification_key(phone_number), True)
+    # 실패: 유효하지 않은 데이터(잘못된 필드 값 등)(400)
+    def test_patch_user_info_invalid_data(self):
+        pass
 
-        # 변경할 데이터
-        data = {
-            "profile_img_url": "http://example.com/new_profile.jpg",
-            "password": "securepassword456",
-            "nickname": "newnicky",
-            "phone_number": phone_number,
-            "is_phone_number_verified": True,
-        }
+    # 실패: 필수 필드 누락(400) #? 필요할까?
+    def test_patch_user_info_missing_required_field(self):
+        pass
 
-        response = self.client.patch(self.url, data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        
-        # 데이터가 제대로 변경됐는지 DB 체크
-        for key, check_data in data.items():
-            self.assertEqual(response.data[key], check_data)
+    # 실패: 잘못된 인증 코드(400)
+    def test_patch_user_info_invalid_verification_code(self):
+        pass
 
-    # 로그인한 사용자의 정보 수정: 휴대폰 인증을 하지 않은 버전(실패 케이스)
-    def test_patch_user_info_without_verification(self):
-        self.client.force_authenticate(self.user)
+    # 실패: 인증 코드 누락(400)
+    def test_patch_user_info_without_verification_code(self):
+        pass
 
-        data = {
-            "phone_number": "01011112222",
-            "is_phone_number_verified": False,
-        }
-
-        response = self.client.patch(self.url, data, content_type="application/json")
-        self.assertEqual(response.status_code, 400)
-        self.assertIn("휴대폰 인증이 필요합니다.", response.json()["detail"])
-
-    def test_patch_user_info_unauthenticated(self):
-        data = {
-            "nickname": "anonymous",
-        }
-
-        response = self.client.patch(self.url, data, content_type="application/json")
-        self.assertEqual(response.status_code, 401)
+    # 실패: 이미 등록된 전화번호(400/409)
+    def test_patch_user_info_phone_number_duplicate(self):
+        pass

--- a/apps/users/urls/users_urls.py
+++ b/apps/users/urls/users_urls.py
@@ -1,4 +1,5 @@
 from django.urls import URLPattern, URLResolver, path
+
 from apps.users.views.user_info_view import UserInfoView
 
 urlpatterns: list[URLPattern | URLResolver] = [

--- a/apps/users/urls/users_urls.py
+++ b/apps/users/urls/users_urls.py
@@ -1,7 +1,8 @@
 from django.urls import URLPattern, URLResolver, path
 
-from apps.users.views.user_info_view import UserInfoView
+from apps.users.views.user_info_view import UserInfoEditView, UserInfoView
 
 urlpatterns: list[URLPattern | URLResolver] = [
     path("info/", UserInfoView.as_view(), name="user_info"),
+    path("info/edit/", UserInfoEditView.as_view(), name="user_info_edit"),
 ]

--- a/apps/users/urls/users_urls.py
+++ b/apps/users/urls/users_urls.py
@@ -1,3 +1,6 @@
 from django.urls import URLPattern, URLResolver, path
+from apps.users.views.user_info_view import UserInfoView
 
-urlpatterns: list[URLPattern | URLResolver] = []
+urlpatterns: list[URLPattern | URLResolver] = [
+    path("info/", UserInfoView.as_view(), name="user_info"),
+]

--- a/apps/users/views/user_info_view.py
+++ b/apps/users/views/user_info_view.py
@@ -1,6 +1,7 @@
 # apps/users/views/user_info_view.py
 
-from django.contrib.auth.models import AnonymousUser
+from typing import cast
+
 from rest_framework import status
 from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
@@ -9,49 +10,39 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.users.models.user import User
-from apps.users.serializers.user_info_serializer import UserInfoSerializer
-from apps.users.services.user_info_service import UserInfoEditService
+from apps.users.services.user_info_service import (
+    UserInfoEditService,
+    UserInfoService,
+)
 
-
-class UserInfoView(APIView):
+# 로그인한 사용자만 접근할 수 있는 APIView 기본 클래스: permission_classes를 IsAuthenticated로 고정
+class AuthenticatedAPIview(APIView):
     permission_classes = [IsAuthenticated]
 
+class UserInfoView(AuthenticatedAPIview):
     def get(self, request: Request) -> Response:
         """
-        현재 로그인한 사용자의 정보를 반환(정보 조회).
+        자신(로그인한 사용자)의 정보 조회.
         """
-        assert not isinstance(request.user, AnonymousUser)
-        user: User = request.user # mypy
+        service = UserInfoService(cast(User, request.user))
+        data = service.get_user_info()
 
-        serializer = UserInfoSerializer(request.user)
-        return Response(serializer.data)
+        return Response(data, status=status.HTTP_200_OK)
 
+
+class UserInfoEditView(AuthenticatedAPIview):
     def patch(self, request: Request) -> Response:
         """
-        사용자 정보를 수정.
-        변경 사항에 휴대폰 번호가 포함되어 있다면, service에서 인증 여부를 확인하고 캐시를 삭제.
-        """
-        # 오류: 비로그인 유저(401)
-        if isinstance(request.user, AnonymousUser):
-            return Response({"detail": "로그인이 필요합니다."}, status=status.HTTP_401_UNAUTHORIZED)
-    
-        try:
-            assert not isinstance(request.user, AnonymousUser)
-            user: User = request.user # mypy
+        현재 로그인한 사용자의 정보를 수정하는 API 뷰.
+        로그인 필수. 휴대폰 번호 변경 시 인증 코드 검증 포함.
+        """ 
+        # 로그인한 사용자를 기반으로 서비스 인스턴스 생성
+        service = UserInfoEditService(cast(User, request.user))
 
-            # 사용자 정보 수정 서비스 호출
-            updated_user = UserInfoEditService(request.user).update_user_info(request.data)
+        try: # 사용자 정보 업데이트
+            service.update_user_info(request.data)
+        except ValidationError as e: # ValidationError의 종류가 달라도 안전하게 Response를 반환
+            detail = getattr(e, "detail", str(e))
+            return Response({"detail": detail}, status=status.HTTP_400_BAD_REQUEST)
 
-            # 수정된 사용자 정보를 다시 직렬화하여 응답
-            serializer = UserInfoSerializer(updated_user)
-            return Response(serializer.data, status=status.HTTP_200_OK)
-
-        except ValidationError as e:
-            # 오류: 인증/유효성 검사 실패(400)
-            print(f"인증에 실패하였습니다. {str(e)}.")
-            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
-
-        except Exception as e:
-            # 오류: 알 수 없는 오류(500)
-            print(f"Unexpected error during user info update: {str(e)}")
-            return Response({"detail": "알 수 없는 오류가 발생했습니다."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+        return Response({"detail": "회원 정보가 성공적으로 수정되었습니다."}, status=status.HTTP_200_OK)

--- a/apps/users/views/user_info_view.py
+++ b/apps/users/views/user_info_view.py
@@ -1,0 +1,1 @@
+# apps/users/serializers/user_info_view.py

--- a/apps/users/views/user_info_view.py
+++ b/apps/users/views/user_info_view.py
@@ -2,6 +2,7 @@
 
 from typing import cast
 
+from drf_spectacular.utils import OpenApiExample, OpenApiResponse, extend_schema
 from rest_framework import status
 from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
@@ -10,39 +11,139 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.users.models.user import User
+from apps.users.serializers.user_info_serializer import UserInfoSerializer
 from apps.users.services.user_info_service import (
     UserInfoEditService,
     UserInfoService,
 )
 
+
 # 로그인한 사용자만 접근할 수 있는 APIView 기본 클래스: permission_classes를 IsAuthenticated로 고정
 class AuthenticatedAPIview(APIView):
     permission_classes = [IsAuthenticated]
 
+
+# 사용자 정보 조회 extend_schema
+@extend_schema(
+    summary="내 정보 조회",  # API 목적 요약
+    description="로그인한 사용자가 자신의 정보를 조회합니다.",  # API 설명
+    responses={
+        200: OpenApiResponse(description="사용자 정보 조회 성공."),  # 성공 응답
+        401: OpenApiResponse(
+            description="인증 정보 없음. 로그인 필요."
+        ),  # 실패 응답(인증 정보가 없음: 비로그인 사용자 등)
+        403: OpenApiResponse(
+            description="권한 없는 사용자."
+        ),  # 실패 응답(인증은 됐지만 권한이 없음: 로그인 후 타 사용자의 정보를 조회하려는 경우 등)
+    },
+)
+
+# 사용자 정보 조회
 class UserInfoView(AuthenticatedAPIview):
     def get(self, request: Request) -> Response:
         """
         자신(로그인한 사용자)의 정보 조회.
         """
-        service = UserInfoService(cast(User, request.user))
+        user = cast(User, request.user)
+        service = UserInfoService(user)  # 서비스 호출
         data = service.get_user_info()
 
         return Response(data, status=status.HTTP_200_OK)
 
 
+# 사용자 정보 수정 extend_schema
+@extend_schema(
+    summary="내 정보 수정",  # API 목적 요약
+    description="로그인한 사용자가 자신의 정보를 수정합니다. 휴대폰 번호 변경 시 인증 코드 검증이 필요합니다.",  # API 설명
+    request={  # 어떤 필드를 수정할 수 있는지 시각화
+        "application/json": {
+            "type": "object",
+            "properties": {
+                "profile_img_url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "프로필 이미지의 URL",
+                },  # profile_img_url = models.URLField(max_length=255, null=True, blank=True, help_text="프로필 이미지")
+                "password": {"type": "string", "example": "newpassword"},
+                "nickname": {"type": "string", "example": "newnickname"},
+                "phone_number": {"type": "string", "example": "01012345678"},
+                "verification_code": {"type": "string", "example": "123456"},  # 수정은 불가
+            },
+            "required": ["phone_number"],
+        }
+    },
+    responses={  # 어떤 상황에서 발생하는지에 관한 설명
+        200: OpenApiResponse(description="회원 정보 수정 성공."),  # 성공 응답(모든 필드 유효)
+        400: OpenApiResponse(
+            description="요청 데이터 오류 또는 인증 코드 검증 실패."
+        ),  # 실패 응답(요청 자체가 잘못됨: 정보 편집 시 필수 데이터를 빠트리고 저장한 경우 등)
+        401: OpenApiResponse(
+            description="인증 코드 없음 혹은 인증 실패."
+        ),  # 실패 응답(인증되지 않았거나 인증 정보가 없음: 로그인이 필요하거나 인증 토큰이 없는 경우 등)
+        403: OpenApiResponse(
+            description="권한 없는 사용자."
+        ),  # 실패 응답(인증은 됐지만 접근 권한이 없음: 로그인 후 타 사용자의 정보를 수정하려는 경우 등)
+    },
+    examples=[  # 실제 사용 예시
+        OpenApiExample(
+            name="프로필 이미지 변경",
+            value={"profile_img_url": "http://example.com/profile.jpg"},
+            request_only=True,
+        ),
+        OpenApiExample(
+            name="비밀번호 변경",
+            value={"password": "newpassword"},
+            request_only=True,
+        ),
+        OpenApiExample(
+            name="닉네임 변경",
+            value={"nickname": "newnicky"},  # 10글지 이내여야 함
+            request_only=True,
+        ),
+        OpenApiExample(
+            name="휴대폰 번호 변경",
+            value={"phone_number": "01098765432", "verification_code": "654321"},
+            request_only=True,
+        ),
+        OpenApiExample(
+            name="여러 항목 동시 수정",
+            value={
+                "nickname": "upuser",
+                "password": "strongpw-123",
+                "phone_number": "01011112222",
+                "verification_code": "112233",
+            },
+            request_only=True,
+        ),
+    ],
+)
+
+# 사용자 정보 수정
 class UserInfoEditView(AuthenticatedAPIview):
     def patch(self, request: Request) -> Response:
         """
         현재 로그인한 사용자의 정보를 수정하는 API 뷰.
         로그인 필수. 휴대폰 번호 변경 시 인증 코드 검증 포함.
-        """ 
-        # 로그인한 사용자를 기반으로 서비스 인스턴스 생성
-        service = UserInfoEditService(cast(User, request.user))
+        """
+        # 로그인한 사용자(User)를 서비스 코드로 넘겨 사용자 정보를 수정하는 서비스 생성
+        user = cast(User, request.user)
+        service = UserInfoEditService(user)
 
-        try: # 사용자 정보 업데이트
-            service.update_user_info(request.data)
-        except ValidationError as e: # ValidationError의 종류가 달라도 안전하게 Response를 반환
+        try:
+            updated_user = service.update_user_info(request.data)  # 서비스 호출
+        except ValidationError as e:
+            # ValidationError는 보통 detail에 오류 내용을 담고 있으므로, 만약 detail이 있다면 그것을 가져오고, 그렇지 않다면 str(e)를 반환한다
             detail = getattr(e, "detail", str(e))
+
+            # 인증 코드 미입력
+            if "휴대폰 번호 변경 시 인증 코드가 필요합니다." in str(detail):
+                return Response({"detail": detail}, status=status.HTTP_401_UNAUTHORIZED)
+
+            # 기타 오류들
             return Response({"detail": detail}, status=status.HTTP_400_BAD_REQUEST)
 
-        return Response({"detail": "회원 정보가 성공적으로 수정되었습니다."}, status=status.HTTP_200_OK)
+        # 수정 성공
+        serializer = UserInfoSerializer(updated_user)
+        return Response(
+            {"message": "회원 정보가 정상적으로 수정되었습니다.", "user": serializer.data}, status=status.HTTP_200_OK
+        )

--- a/apps/users/views/user_info_view.py
+++ b/apps/users/views/user_info_view.py
@@ -1,1 +1,57 @@
-# apps/users/serializers/user_info_view.py
+# apps/users/views/user_info_view.py
+
+from django.contrib.auth.models import AnonymousUser
+from rest_framework import status
+from rest_framework.exceptions import ValidationError
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.users.models.user import User
+from apps.users.serializers.user_info_serializer import UserInfoSerializer
+from apps.users.services.user_info_service import UserInfoEditService
+
+
+class UserInfoView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request: Request) -> Response:
+        """
+        현재 로그인한 사용자의 정보를 반환(정보 조회).
+        """
+        assert not isinstance(request.user, AnonymousUser)
+        user: User = request.user # mypy
+
+        serializer = UserInfoSerializer(request.user)
+        return Response(serializer.data)
+
+    def patch(self, request: Request) -> Response:
+        """
+        사용자 정보를 수정.
+        변경 사항에 휴대폰 번호가 포함되어 있다면, service에서 인증 여부를 확인하고 캐시를 삭제.
+        """
+        # 오류: 비로그인 유저(401)
+        if isinstance(request.user, AnonymousUser):
+            return Response({"detail": "로그인이 필요합니다."}, status=status.HTTP_401_UNAUTHORIZED)
+    
+        try:
+            assert not isinstance(request.user, AnonymousUser)
+            user: User = request.user # mypy
+
+            # 사용자 정보 수정 서비스 호출
+            updated_user = UserInfoEditService(request.user).update_user_info(request.data)
+
+            # 수정된 사용자 정보를 다시 직렬화하여 응답
+            serializer = UserInfoSerializer(updated_user)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+
+        except ValidationError as e:
+            # 오류: 인증/유효성 검사 실패(400)
+            print(f"인증에 실패하였습니다. {str(e)}.")
+            return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+
+        except Exception as e:
+            # 오류: 알 수 없는 오류(500)
+            print(f"Unexpected error during user info update: {str(e)}")
+            return Response({"detail": "알 수 없는 오류가 발생했습니다."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)

--- a/apps/users/views/withdrawals_view.py
+++ b/apps/users/views/withdrawals_view.py
@@ -1,5 +1,6 @@
 # apps/users/views/withdrawals_view.py
 
+from drf_spectacular.utils import OpenApiExample, OpenApiResponse, extend_schema
 from rest_framework import status
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.request import Request
@@ -26,6 +27,23 @@ email_service = EmailVerificationService()
 
 
 class WithdrawalAPIView(APIView):
+    @extend_schema(
+        summary="계정 탈퇴 요청",
+        description="로그인한 사용자가 계정 탈퇴를 요청합니다. 성공 시 탈퇴 기록이 생성됩니다.",
+        request=WithdrawalRequestSerializer,
+        responses={
+            200: WithdrawalResponseSerializer,
+            401: OpenApiResponse(description="로그인이 필요합니다."),
+            400: OpenApiResponse(description="잘못된 요청 데이터."),
+        },
+        examples=[
+            OpenApiExample(
+                "계정 탈퇴 요청 예시",
+                value={"reason": "서비스 불만족"},
+                request_only=True,
+            ),
+        ],
+    )
     def post(self, request: Request) -> Response:
         assert request.user.is_authenticated  # mypy 오류로 인한 검증 코드
         request_serializer = WithdrawalRequestSerializer(data=request.data, context={"request": request})
@@ -45,6 +63,24 @@ class AccountRecoveryAPIView(APIView):
     └ 복구 성공 시 계정 활성화 및 탈퇴 요청 삭제
     """
 
+    @extend_schema(
+        summary="탈퇴 계정 복구 요청",
+        description="탈퇴 계정을 이메일 인증을 통해 복구합니다. 성공 시 계정이 활성화되고 탈퇴 기록은 삭제됩니다.",
+        request=EmailVerifyCodeSerializer,
+        responses={
+            200: OpenApiResponse(description="계정 복구 성공"),
+            400: OpenApiResponse(description="잘못된 인증 코드 또는 기타 요청 오류"),
+            404: OpenApiResponse(description="탈퇴 요청이 존재하지 않음"),
+            500: OpenApiResponse(description="이메일 발송 시스템 오류"),
+        },
+        examples=[
+            OpenApiExample(
+                "계정 복구 요청 예시",
+                value={"email": "user@example.com", "verification_code": "123456"},
+                request_only=True,
+            )
+        ],
+    )
     def post(self, request: Request) -> Response:
         # 1) 유효성 검증
         serializer = EmailVerifyCodeSerializer(data=request.data)
@@ -76,7 +112,5 @@ class AccountRecoveryAPIView(APIView):
         except Withdrawals.DoesNotExist as e:
             return Response({"detail": str(e)}, status=status.HTTP_404_NOT_FOUND)
 
-        except Exception as e:
-            return Response(
-                {"detail": f"알 수 없는 오류가 발생했습니다. {str(e)}."}, status=status.HTTP_400_BAD_REQUEST
-            )
+        except Exception:
+            return Response({"detail": "알 수 없는 오류가 발생했습니다."}, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #203 
- 작업 요약: 회원 정보 조회/수정을 요청하는 API 작성(구현).

## 📄 상세 내용
- [x] `apps/users/serializers/user_info.py`: 조회할 사용자 정보 직렬화. 인증 코드 검증 후 실제 DB에 반영.
- [x] `apps/users/services/user_info.py`: 비밀번호 변경 시 암호화해서 저장. 변경된 정보가 있다면 시리얼라이저를 통한 검증 후 문제가 없다면 정보 갱신.
- [x] `apps/users/views/user_info.py`: 로그인한 사용자가 자신의 정보를 조회(인증 정보 혹은 권한이 없다면 HTTP 예외 발생). 로그인한 사용자가 자신의 정보를 수정(인증 코드 미입력 혹은 요청 데이터에 오류가 있다면 HTTP 예외 발생). Swagger 대응용 extend schema 사용(API 문서화).

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [X] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [X] 변경 사항에 대한 테스트를 했습니다(버그 수정/기능에 대한 테스트).