### PR TITLE
스터디 그룹 탈퇴 API

### DIFF
--- a/apps/studies/permissions.py
+++ b/apps/studies/permissions.py
@@ -31,6 +31,21 @@ class IsStudyGroupLeaderPermission(permissions.BasePermission):
         return study_group.members.through.objects.filter(user=request.user, is_leader=True).exists()
 
 
+class IsStudyGroupMemberPermission(permissions.BasePermission):
+    """
+    스터디 그룹원 여부 확인
+    """
+
+    def has_object_permission(self, request: Request, view: APIView, obj: Any) -> Any:
+        """
+        :param request: HTTP request
+        :param view: APIView
+        :param obj: StudyGroup 인스턴스
+        :return: bool
+        """
+        return obj.members.through.objects.filter(user=request.user).exists()
+
+
 class IsReviewAuthor(permissions.BasePermission):
     message = "본인이 작성한 리뷰만 수정할 수 있습니다."
 

--- a/apps/studies/services/delete_member_service.py
+++ b/apps/studies/services/delete_member_service.py
@@ -1,0 +1,29 @@
+from rest_framework.exceptions import PermissionDenied
+
+from apps.studies.models.study_groups import StudyGroup
+from apps.users.models import User
+
+
+class DeleteMemberService:
+    """
+    스터디 그룹 멤버 삭제 서비스
+    그룹 탈퇴, 강퇴 기능 구현.
+    """
+
+    def __init__(self, group: StudyGroup, user: User) -> None:
+        self.group = group
+        self.target = user
+
+    def check_leader(self) -> bool:
+        """
+        탈퇴, 강퇴 요청 시 해당되는 유저가 그룹 리더인지 체크
+        """
+        return self.group.members.through.objects.get(user=self.target, study_group=self.group).is_leader
+
+    def studygroup_withdraw_service(self) -> None:
+        """
+        스터디 그룹 탈퇴 기능
+        """
+        if self.check_leader():
+            raise PermissionDenied("그룹 리더는 리더 위임 후 그룹을 탈퇴할 수 있습니다.")
+        self.group.members.remove(self.target)

--- a/apps/studies/tests/test_withdraw_studygroup.py
+++ b/apps/studies/tests/test_withdraw_studygroup.py
@@ -1,0 +1,83 @@
+import logging
+from datetime import datetime
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.core.tests.mixins.test_user_mixins import TestUserMixin
+from apps.lectures.models import Lecture
+from apps.lectures.models.crawled_lectures import DifficultyChoices, PlatformChoices
+from apps.studies.models import GroupMember, StudyGroup
+from apps.studies.serializers.study_group import StudyGroupCreateUpdateSerializer
+
+logger = logging.getLogger(__name__)
+
+
+class WithdrawStudyGroupAPITest(APITestCase, TestUserMixin):
+    """
+    스터디 그룹원이 스터디 그룹에서 탈퇴하는 기능 테스트
+    """
+
+    def setUp(self) -> None:
+        # 테스트를 위한 유저 생성
+        self.leader = self._create_test_user()  # 스터디 그룹 리더
+        self.member = self._create_test_user(
+            email="kimshineday@test.com", nickname="김빛날", phone_number="01098765432"
+        )  # 스터디 그룹원
+        self.test_user = self._create_test_user(email="test@test.com", nickname="test", phone_number="01000000000")
+
+        # 스터디 그룹 생성
+        self.lecture = Lecture.objects.create(
+            title="test lecture",
+            instructor="김인직",
+            average_rating=4.23,
+            duration=20,
+            difficulty=DifficultyChoices.NORMAL,
+            description="testtest",
+            platform=PlatformChoices.INFLEARN,
+            original_price=40000,
+            discount_price=32000,
+            url_link="https://ozcoding.site/lectures/1",
+        )
+        self.data = {
+            "name": "스터디 그룹 탈퇴 테스트",
+            "introduction": "기본 데이터 생성",
+            "max_headcount": 3,
+            "start_at": datetime(2025, 10, 15),
+            "end_at": datetime(2025, 10, 30),
+            "lectures": [self.lecture.id],
+        }
+        self.group = StudyGroupCreateUpdateSerializer(data=self.data)
+        self.assertTrue(self.group.is_valid(raise_exception=True))
+        self.group.save(user=self.leader)
+        self.study_group_member = GroupMember.objects.create(
+            user=self.member, study_group=StudyGroup.objects.get(uuid=self.group.data["uuid"])
+        )
+        self.url = reverse("withdraw_study_group", kwargs={"group_uuid": self.group.data["uuid"]})
+
+    def test_delete_fail_1(self) -> None:
+        """
+        스터디 그룹원이 아닌 경우 fail case
+        """
+        self.client.force_authenticate(user=self.test_user)  # 그룹원이 아닌 사람
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        logger.debug(response.data)
+
+    def test_delete_fail_2(self) -> None:
+        """
+        스터디 그룹 리더인 경우 fail case
+        """
+        self.client.force_authenticate(user=self.leader)  # 스터디 그룹 리더
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        logger.debug(response.data)
+
+    def test_delete_success(self) -> None:
+        """
+        success case!
+        """
+        self.client.force_authenticate(user=self.member)  # 스터디 그룹원
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/apps/studies/urls/study_group.py
+++ b/apps/studies/urls/study_group.py
@@ -1,5 +1,6 @@
 from django.urls import path
 
+from apps.studies.views.group_member_delete_view import WithdrawGroupMemberView
 from apps.studies.views.leader_delegate_view import StudyGroupLeaderDelegateView
 from apps.studies.views.study_group_create_view import CreateStudyGroupView
 from apps.studies.views.study_group_update_view import UpdateStudyGroupView
@@ -8,4 +9,5 @@ urlpatterns = [
     path("", CreateStudyGroupView.as_view(), name="create_study_group"),
     path("/<uuid:group_uuid>", UpdateStudyGroupView.as_view(), name="update_study_group"),
     path("/<uuid:group_uuid>/delegate", StudyGroupLeaderDelegateView.as_view(), name="leader_delegate"),
+    path("/<uuid:group_uuid>/withdraw", WithdrawGroupMemberView.as_view(), name="withdraw_study_group"),
 ]

--- a/apps/studies/views/group_member_delete_view.py
+++ b/apps/studies/views/group_member_delete_view.py
@@ -1,0 +1,34 @@
+from typing import cast
+
+from django.shortcuts import get_object_or_404
+from drf_spectacular.utils import extend_schema
+from rest_framework import status
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.studies.models import StudyGroup
+from apps.studies.permissions import IsStudyGroupMemberPermission
+from apps.studies.services.delete_member_service import DeleteMemberService
+from apps.users.models import User
+
+
+class WithdrawGroupMemberView(APIView):
+    """
+    스터디 그룹원이 그룹 탈퇴 요청시 처리 로직
+    """
+
+    permission_classes = [IsStudyGroupMemberPermission]
+
+    @extend_schema(
+        summary="스터디 그룹 탈퇴 API",
+        description="스터디 그룹의 모든 멤버들은 스터디 그룹에서 탈퇴할 수 있습니다.",
+        tags=["Study Group"],
+    )
+    def delete(self, request: Request, group_uuid: str) -> Response:
+        group = get_object_or_404(StudyGroup, uuid=group_uuid)
+        self.check_object_permissions(request, group)
+        user = cast(User, request.user)
+        delete_member = DeleteMemberService(group=group, user=user)
+        delete_member.studygroup_withdraw_service()
+        return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #157 
- 작업 요약: 스터디 그룹 탈퇴 API 기능 구현

## 📄 상세 내용
- [ ] GroupMember에서 데이터 삭제 로직
- [ ] test code 작성
- [ ] 리더가 그룹 탈퇴 요청시 에러 발생 -> 리더는 그룹원 중 한 사람에게 리더 위임을 한 후에 탈퇴 가능

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
