### PR TITLE
✨  feat     : 구인 공고 작성 API

### DIFF
--- a/apps/recruitments/serializers/recruitments_serializers.py
+++ b/apps/recruitments/serializers/recruitments_serializers.py
@@ -1,7 +1,8 @@
 from functools import partial
-from typing import Any
+from typing import Any, Dict
 
 from django.db import transaction
+from django.db.models import Sum
 from rest_framework import serializers
 
 from apps.lectures.models.crawled_lectures import Lecture
@@ -153,3 +154,94 @@ class RecruitmentUpdateSerializer(serializers.ModelSerializer[Recruitment]):
 
     def _cleanup_orphan_images_or_attachments(self, urls: list[str]) -> None:
         S3Uploader().delete_files(urls)
+
+
+# 공고 작성에 사용(첨부파일 가공)
+class AttachmentInputSerializer(serializers.Serializer[RecruitmentAttachment]):
+    file_url = serializers.URLField(max_length=255)
+    file_name = serializers.CharField(max_length=50)
+
+
+# 공고 작성 시리얼라이저
+class RecruitmentCreateOutputSerializer(serializers.ModelSerializer[Recruitment]):
+    class Meta:
+        model = Recruitment
+        fields = ["uuid", "title"]
+
+
+class RecruitmentCreateSerializer(serializers.ModelSerializer[Recruitment]):
+    images = serializers.ListField(child=serializers.URLField(), max_length=5, required=False)
+    attachments = AttachmentInputSerializer(many=True, required=False)
+    tags = serializers.ListField(child=serializers.IntegerField(), required=False)
+    author = serializers.HiddenField(default=serializers.CurrentUserDefault())
+
+    class Meta:
+        model = Recruitment
+        fields = [
+            "author",
+            "title",
+            "content",
+            "close_at",
+            "expected_headcount",
+            "study_group",
+            "images",
+            "attachments",
+            "estimated_fee",
+            "tags",
+        ]
+        extra_kwargs = {
+            "images": {"write_only": True},
+            "attachments": {"write_only": True},
+            "estimated_fee": {"required": False},
+            "tags": {"write_only": True},
+        }
+
+    def validate(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        # 첨부파일 제한
+        attachments = data.get("attachments")
+        if attachments and len(attachments) > 3:
+            raise serializers.ValidationError({"attachments": "첨부 파일은 최대 3개까지 등록 가능합니다."})
+
+        # 스터디그룹 상태 제한
+        study_group = data.get("study_group")
+        if study_group and study_group.status == "ENDED":
+            raise serializers.ValidationError({"study_group": "종료된 스터디 그룹은 등록 불가능합니다."})
+
+        return data
+
+    def create(self, validated_data: Dict[str, Any]) -> Recruitment:
+        images = validated_data.pop("images", None)
+        attachments = validated_data.pop("attachments", None)
+        tags = validated_data.pop("tags", None)
+
+        # estimated_fee를 입력하지 않았다면 스터디그룹의 강의 비용을 합산해서 자동 등록
+        if "estimated_fee" not in validated_data:
+            study_group = validated_data["estimated_fee"]
+            total = study_group.lectures.aggregate(total=Sum("original_price"))["total"]
+            if total is None:
+                total = 0
+            validated_data["estimated_fee"] = total
+
+        # recruitment는 등록
+        recm = Recruitment.objects.create(**validated_data)
+
+        # 이미지 등록
+        if images is not None:
+            image_list = []
+            for i in images:
+                image_list.append(RecruitmentImage(recruitment=recm, img_url=i))
+            RecruitmentImage.objects.bulk_create(image_list)
+
+        # 첨부 파일 등록
+        if attachments is not None:
+            attachment_list = []
+            for i in attachments:
+                attachment_list.append(
+                    RecruitmentAttachment(recruitment=recm, file_url=i["file_url"], file_name=i["file_name"])
+                )
+            RecruitmentAttachment.objects.bulk_create(attachment_list)
+
+        if tags is not None:
+            recm.tags.set(tags)
+
+        return recm

--- a/apps/recruitments/serializers/recruitments_serializers.py
+++ b/apps/recruitments/serializers/recruitments_serializers.py
@@ -1,11 +1,12 @@
 from functools import partial
-from typing import Any, Dict
+from typing import Any, Dict, Final
 
 from django.db import transaction
 from django.db.models import Sum
 from rest_framework import serializers
 
 from apps.lectures.models.crawled_lectures import Lecture
+from apps.studies.models.study_groups import StudyGroup
 from apps.users.models.user import User
 
 from ...core.utils import S3Uploader
@@ -198,17 +199,19 @@ class RecruitmentCreateSerializer(serializers.ModelSerializer[Recruitment]):
 
     def validate(self, data: Dict[str, Any]) -> Dict[str, Any]:
         # 첨부파일 제한
+        MAX_RECRUITMENT_ATTACHMENTS_COUNT: Final = 3
         attachments = data.get("attachments")
-        if attachments and len(attachments) > 3:
+        if attachments and len(attachments) > MAX_RECRUITMENT_ATTACHMENTS_COUNT:
             raise serializers.ValidationError({"attachments": "첨부 파일은 최대 3개까지 등록 가능합니다."})
 
         # 스터디그룹 상태 제한
         study_group = data.get("study_group")
-        if study_group and study_group.status == "ENDED":
+        if study_group and study_group.status == StudyGroup.StatusChoices.ENDED:
             raise serializers.ValidationError({"study_group": "종료된 스터디 그룹은 등록 불가능합니다."})
 
         return data
 
+    @transaction.atomic
     def create(self, validated_data: Dict[str, Any]) -> Recruitment:
         images = validated_data.pop("images", None)
         attachments = validated_data.pop("attachments", None)

--- a/apps/recruitments/serializers/recruitments_serializers.py
+++ b/apps/recruitments/serializers/recruitments_serializers.py
@@ -216,7 +216,7 @@ class RecruitmentCreateSerializer(serializers.ModelSerializer[Recruitment]):
 
         # estimated_fee를 입력하지 않았다면 스터디그룹의 강의 비용을 합산해서 자동 등록
         if "estimated_fee" not in validated_data:
-            study_group = validated_data["estimated_fee"]
+            study_group = validated_data["study_group"]
             total = study_group.lectures.aggregate(total=Sum("original_price"))["total"]
             if total is None:
                 total = 0

--- a/apps/recruitments/tests/test_post_recruitment.py
+++ b/apps/recruitments/tests/test_post_recruitment.py
@@ -1,0 +1,135 @@
+from datetime import datetime, timedelta
+
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.lectures.models.crawled_lectures import Lecture
+from apps.recruitments.models.recruitments import Recruitment
+from apps.recruitments.models.tags import Tag
+from apps.studies.models.study_groups import StudyGroup
+from apps.studies.models.study_lectures import StudyLecture
+from apps.users.models.user import User
+
+
+class RecruitmentPostTestCase(APITestCase):
+    def setUp(self) -> None:
+        study_groups = []
+        study_groups.append(
+            StudyGroup(
+                name="test_group",
+                max_headcount=5,
+                start_at=timezone.now(),
+                end_at=timezone.now() + timedelta(days=1),
+            )
+        )
+        study_groups.append(
+            StudyGroup(
+                name="test_group_ended",
+                max_headcount=5,
+                start_at=timezone.now(),
+                end_at=timezone.now() + timedelta(days=1),
+                status="ENDED",
+            )
+        )
+        self.study_groups = StudyGroup.objects.bulk_create(study_groups)
+
+        lectures = []
+        lectures.append(
+            Lecture(
+                title="lecture 1",
+                instructor="instructor 1",
+                duration=5,
+                description="description 1",
+                platform="udemy",
+                url_link="https://www.test.com",
+                original_price=10000,
+            )
+        )
+        lectures.append(
+            Lecture(
+                title="lecture 2",
+                instructor="instructor 2",
+                duration=5,
+                description="description 2",
+                platform="udemy",
+                url_link="https://www.test.com",
+                original_price=30000,
+            )
+        )
+        self.lectures = Lecture.objects.bulk_create(lectures)
+        study_lectures = [
+            StudyLecture(lecture=self.lectures[0], study_group=self.study_groups[0]),
+            StudyLecture(lecture=self.lectures[1], study_group=self.study_groups[0]),
+        ]
+        StudyLecture.objects.bulk_create(study_lectures)
+
+        self.author = User.objects.create_user(
+            email=f"testuser@test.com",
+            password="itspassword",
+            name="test",
+            nickname="testuser",
+            phone_number=f"010-0000-0000",
+            gender="male",
+            birthday=timezone.make_aware(datetime(2025, 9, 9)),
+        )
+        self.client.force_authenticate(user=self.author)
+
+        tags = [Tag(name="tag1"), Tag(name="tag2"), Tag(name="tag3")]
+        self.tags = Tag.objects.bulk_create(tags)
+
+    def test_post_recruitment(self) -> None:
+        url = reverse("recruitment-list-post")
+        data = {
+            "title": "자바스크립트 스터디원 모집합니다!",
+            "content": "함께 성장할 스터디원을 모집합니다.",
+            "close_at": "2025-10-01T23:59:59",
+            "expected_headcount": 3,
+            "study_group": self.study_groups[0].id,
+            "images": ["http://example.com/img1.jpg", "http://example.com/img2.jpg"],
+            "attachments": [
+                {"file_url": "http://example.com/file1.pdf", "file_name": "file_name_1"},
+                {"file_url": "http://example.com/file2.pdf", "file_name": "file_name_2"},
+            ],
+            "estimated_fee": 10000,
+            "tags": [self.tags[0].id, self.tags[2].id],
+        }
+        res = self.client.post(url, data=data, format="json")
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(res.data["title"], data["title"])
+
+    # 결제 비용 자동 합산 확인
+    def test_sum_estimated_fee(self) -> None:
+        url = reverse("recruitment-list-post")
+        data = {
+            "title": "결제 비용 자동 합산",
+            "content": "함께 성장할 스터디원을 모집합니다.",
+            "close_at": "2025-10-01T23:59:59",
+            "expected_headcount": 3,
+            "study_group": self.study_groups[0].id,
+        }
+        res = self.client.post(url, data=data, format="json")
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+
+        recm = Recruitment.objects.get()
+        self.assertEqual(recm.estimated_fee, 40000)
+
+    def test_post_error(self) -> None:
+        url = reverse("recruitment-list-post")
+        data = {
+            "title": "자바스크립트 스터디원 모집합니다!",
+            "content": "함께 성장할 스터디원을 모집합니다.",
+            "close_at": "2025-10-01T23:59:59",
+            "expected_headcount": 3,
+            "study_group": self.study_groups[0].id,
+            "attachments": [
+                {"file_url": "http://example.com/file1.pdf", "file_name": "file_name_1"},
+                {"file_url": "http://example.com/file2.pdf", "file_name": "file_name_2"},
+                {"file_url": "http://example.com/file3.pdf", "file_name": "file_name_3"},
+                {"file_url": "http://example.com/file4.pdf", "file_name": "file_name_4"},
+            ],
+        }
+
+        res = self.client.post(url, data=data, format="json")
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)

--- a/apps/recruitments/tests/tests_list.py
+++ b/apps/recruitments/tests/tests_list.py
@@ -158,7 +158,7 @@ class RecruitmentsListTestCase(APITestCase):
         self.client.force_authenticate(user=self.users[1])
 
     def test_list_get(self) -> None:
-        url = reverse("recruitment-list")
+        url = reverse("recruitment-list-post")
         query_params: Dict[str, Union[int, str]] = {"page": 1, "ordering": "created_at"}
         res = self.client.get(url, query_params)
         self.assertEqual(res.status_code, 200)
@@ -168,7 +168,7 @@ class RecruitmentsListTestCase(APITestCase):
         self.assertEqual(len(data["tags"]), 3)
 
     def test_list_page(self) -> None:
-        url = reverse("recruitment-list")
+        url = reverse("recruitment-list-post")
         query_params = {"page": 1, "size": 3}
         res = self.client.get(url, query_params)
         self.assertEqual(res.status_code, 200)
@@ -176,7 +176,7 @@ class RecruitmentsListTestCase(APITestCase):
         self.assertEqual(len(results), 3)
 
     def test_list_search(self) -> None:
-        url = reverse("recruitment-list")
+        url = reverse("recruitment-list-post")
         query_params: Dict[str, Union[str, int]] = {"page": 1, "search": "3"}
         res = self.client.get(url, query_params)
         self.assertEqual(res.status_code, 200)
@@ -184,7 +184,7 @@ class RecruitmentsListTestCase(APITestCase):
         self.assertEqual(len(results), 2)
 
     def test_list_order(self) -> None:
-        url = reverse("recruitment-list")
+        url = reverse("recruitment-list-post")
         query_params: Dict[str, Union[str, int]] = {"page": 1, "size": 20, "ordering": "-bookmarks_count,-created_at"}
         res = self.client.get(url, query_params)
         self.assertEqual(res.status_code, 200)
@@ -193,7 +193,7 @@ class RecruitmentsListTestCase(APITestCase):
         self.assertEqual(results[2]["bookmarks_count"], 3)
 
     def test_list_filter(self) -> None:
-        url = reverse("recruitment-list")
+        url = reverse("recruitment-list-post")
         query_params: Dict[str, Union[str, int]] = {"page": 1, "tag": "tag1"}
         res = self.client.get(url, query_params)
         self.assertEqual(res.status_code, 200)

--- a/apps/recruitments/urls/recruitments_urls.py
+++ b/apps/recruitments/urls/recruitments_urls.py
@@ -11,7 +11,7 @@ from apps.recruitments.views.recruitment_detail_views import RecruitmentDetailVi
 from apps.recruitments.views.recruitment_views import MyRecruitmentView, RecruitmentView
 
 urlpatterns = [
-    path("", RecruitmentView.as_view(), name="recruitment-list"),
+    path("", RecruitmentView.as_view(), name="recruitment-list-post"),
     path("/me", MyRecruitmentView.as_view(), name="recruitment-mylist"),
     path("/attachments", RecruitmentFileView.as_view(), name="recruitment-attachments-upload"),
     path("/images", RecruitmentImageView.as_view(), name="recruitment-images-upload"),

--- a/apps/recruitments/views/recruitment_views.py
+++ b/apps/recruitments/views/recruitment_views.py
@@ -1,4 +1,4 @@
-from typing import Self, cast
+from typing import cast
 
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema, inline_serializer
@@ -10,6 +10,10 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.recruitments.managers.managers_list import RecruitmentListQuerySet
+from apps.recruitments.serializers.recruitments_serializers import (
+    RecruitmentCreateOutputSerializer,
+    RecruitmentCreateSerializer,
+)
 from apps.recruitments.serializers.serializers_list import RecruitmentListSerializer
 from apps.recruitments.services.services_list import (
     filter_is_closed,
@@ -109,6 +113,33 @@ class RecruitmentView(APIView):
         serializer = RecruitmentListSerializer(paginated_queryset, many=True)
         return paginator.get_paginated_response(serializer.data)
 
+    @extend_schema(
+        tags=["스터디 구인 공고"],
+        summary="구인 공고 작성",
+        description="스터디 구인 공고 작성이 가능합니다.\n\n"
+        "### 작성 제한\n\n"
+        "1. 이미지 업로드( 최대 5개, 이미지 용량 5MB 이하 )\n\n"
+        "2. 종료되지 않은 스터디 그룹에 대해서만 구인 공고 작성 가능\n\n"
+        "3. 참고 파일 업로드 ( 최대 3개,  파일 용량 5MB 이하 )\n\n"
+        "### 부가 기능\n\n"
+        "예상 결제 비용을 별도로 미입력 시 강의 항목 당 결제 비용을 모두 합산하여 자동 입력",
+        responses={
+            201: RecruitmentCreateOutputSerializer,
+            400: inline_serializer(
+                name="error_validate",
+                fields={
+                    "attachments": serializers.CharField(default="첨부 파일은 최대 3개까지 등록 가능합니다."),
+                    "study_group": serializers.CharField(default="종료된 스터디 그룹은 등록 불가능합니다."),
+                },
+            ),
+        },
+    )
+    def post(self, request: Request) -> Response:
+        serializer = RecruitmentCreateSerializer(data=request.data, context={"request": request})
+        serializer.is_valid(raise_exception=True)
+        new_recm = serializer.save()
+        return Response(RecruitmentCreateOutputSerializer(new_recm).data, status=status.HTTP_201_CREATED)
+
 
 class MyRecruitmentView(APIView):
     permission_classes = [IsAuthenticated]
@@ -160,7 +191,8 @@ class MyRecruitmentView(APIView):
                 },
             ),
             400: inline_serializer(
-                name="get_my_pagelist", fields={"error": serializers.CharField(default="잘못된 is_closed 입력값")}
+                name="error_validate_is_closed",
+                fields={"error": serializers.CharField(default="잘못된 is_closed 입력값")},
             ),
         },
     )


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #193
- 작업 요약: 구인 공고 작성 API 개발

## 📄 상세 내용
- [x] 스터디 구인 공고 작성
- [x] 이미지, 참고 파일, 스터디그룹 상태로 인한 제한
- [x] 별도로 예상 결제 비용을 기입하지 않았다면 자동 입력 기능

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
