### PR TITLE
✨ feat: 회원관리 대시보드 API 구현

### DIFF
--- a/apps/users/services/admin_dashboard_services.py
+++ b/apps/users/services/admin_dashboard_services.py
@@ -1,26 +1,27 @@
-from collections import Counter
-from datetime import datetime
-from typing import Literal, Type, Union
+from enum import Enum
+from typing import Type, Union
 
-from django.db import models
 from django.db.models import Count
 from django.db.models.functions import Trunc
 
 from apps.users.models import User, Withdrawals
 
-Period = Literal["monthly", "yearly"]
+
+class AdminDashboardPeriod(Enum):
+    MONTHLY = "monthly"
+    YEARLY = "yearly"
 
 
 class AdminDashboardService:
     @staticmethod
     # 비공개 헬퍼 메소드
-    def _get_trends_by_model(model: Type[Union[User, Withdrawals]], period: Period) -> dict[str, int]:
+    def _get_trends_by_model(model: Type[Union[User, Withdrawals]], period: AdminDashboardPeriod) -> dict[str, int]:
         """
         비공개 헬퍼, 특정 모델의 생성일 기준 추세를 집계
         """
 
         # 1. 설정한 기간에 따라 Trunc 단위를 결정
-        trunc_kind = "month" if period == "monthly" else "year"
+        trunc_kind = "month" if period == AdminDashboardPeriod.MONTHLY else "year"
 
         # 2. User 모델의 created_at 필드를 월, 년 단위로 나눠 회원 수를 카운트
         trends = (
@@ -36,12 +37,12 @@ class AdminDashboardService:
 
     @staticmethod
     # 회원 가입 추세 집계
-    def get_signup_trends(period: Period) -> dict[str, int]:
+    def get_signup_trends(period: AdminDashboardPeriod) -> dict[str, int]:
         # 비공개 헬퍼 메소드에 User 모델을 전달해서 호출
         return AdminDashboardService._get_trends_by_model(User, period)
 
     @staticmethod
     # 회원 탈퇴 추세 집계
-    def get_withdrawals_trends(period: Period) -> dict[str, int]:
+    def get_withdrawals_trends(period: AdminDashboardPeriod) -> dict[str, int]:
         # 비공개 헬퍼 메소드에 Withdrawals 모델을 전달하여 호출
         return AdminDashboardService._get_trends_by_model(Withdrawals, period)

--- a/apps/users/services/admin_dashboard_services.py
+++ b/apps/users/services/admin_dashboard_services.py
@@ -1,0 +1,47 @@
+from collections import Counter
+from datetime import datetime
+from typing import Literal, Type, Union
+
+from django.db import models
+from django.db.models import Count
+from django.db.models.functions import Trunc
+
+from apps.users.models import User, Withdrawals
+
+Period = Literal["monthly", "yearly"]
+
+
+class AdminDashboardService:
+    @staticmethod
+    # 비공개 헬퍼 메소드
+    def _get_trends_by_model(model: Type[Union[User, Withdrawals]], period: Period) -> dict[str, int]:
+        """
+        비공개 헬퍼, 특정 모델의 생성일 기준 추세를 집계
+        """
+
+        # 1. 설정한 기간에 따라 Trunc 단위를 결정
+        trunc_kind = "month" if period == "monthly" else "year"
+
+        # 2. User 모델의 created_at 필드를 월, 년 단위로 나눠 회원 수를 카운트
+        trends = (
+            model.objects.annotate(period=Trunc("created_at", trunc_kind))
+            .values("period")
+            .annotate(count=Count("id"))
+            .order_by("period")
+        )
+
+        # 3. 결과를 "날짜 : 가입자 수" 형태의 딕셔너리로 반환
+        result = {item["period"].strftime("%Y-%m" if trunc_kind == "month" else "%Y"): item["count"] for item in trends}
+        return result
+
+    @staticmethod
+    # 회원 가입 추세 집계
+    def get_signup_trends(period: Period) -> dict[str, int]:
+        # 비공개 헬퍼 메소드에 User 모델을 전달해서 호출
+        return AdminDashboardService._get_trends_by_model(User, period)
+
+    @staticmethod
+    # 회원 탈퇴 추세 집계
+    def get_withdrawals_trends(period: Period) -> dict[str, int]:
+        # 비공개 헬퍼 메소드에 Withdrawals 모델을 전달하여 호출
+        return AdminDashboardService._get_trends_by_model(Withdrawals, period)

--- a/apps/users/tests/test_admin_dashboard.py
+++ b/apps/users/tests/test_admin_dashboard.py
@@ -1,0 +1,157 @@
+from datetime import date
+from typing import ClassVar
+
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from faker import Faker
+from freezegun import freeze_time
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.users.models import User, Withdrawals
+
+user_model = get_user_model()
+fake = Faker("ko_KR")
+
+
+class AdminDashboardAPITest(APITestCase):
+    superuser: User
+    staff: User
+    general_user: User
+    signup_url: ClassVar[str]
+    withdrawal_url: ClassVar[str]
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        """테스트에서 사용할 유저데이터 생성"""
+        super().setUpTestData()
+
+        # 1. 테스트에 필요한 관리자 및 일반 유저 데이터 생성
+        cls.superuser = user_model.objects.create_superuser(
+            email="superuser@test.com",
+            password="pw",
+            name=fake.name(),
+            nickname=fake.pystr(max_chars=10),
+            phone_number=fake.unique.phone_number(),
+            birthday=fake.date_of_birth(minimum_age=20, maximum_age=40),
+            gender="M",
+        )
+
+        cls.staff = user_model.objects.create_user(
+            email="staff@test.com",
+            password="pw",
+            name=fake.name(),
+            nickname=fake.pystr(max_chars=10),
+            phone_number=fake.unique.phone_number(),
+            birthday=fake.date_of_birth(minimum_age=20, maximum_age=40),
+            gender="M",
+        )
+
+        cls.general_user = user_model.objects.create_user(
+            email="general@test.com",
+            password="pw",
+            name=fake.name(),
+            nickname=fake.pystr(max_chars=10),
+            phone_number=fake.unique.phone_number(),
+            birthday=fake.date_of_birth(minimum_age=20, maximum_age=40),
+            gender="M",
+        )
+
+        # 2. freezegun 라이브러리를 사용해 특정 시간에 데이터를 생성
+        with freeze_time("2023-09-10"):
+            # 23년도에 가입한 유저 1명
+            user_model.objects.create_user(
+                email=fake.unique.email(),
+                password="pw",
+                name=fake.name(),
+                nickname=fake.pystr(max_chars=10),
+                phone_number=fake.unique.phone_number(),
+                birthday=fake.date_of_birth(),
+                gender="M",
+            )
+
+        with freeze_time("2024-05-21"):
+            # 24년도 5월 가입한 유저 2명
+            user_model.objects.create_user(
+                email=fake.unique.email(),
+                password="pw",
+                name=fake.name(),
+                nickname=fake.pystr(max_chars=10),
+                phone_number=fake.unique.phone_number(),
+                birthday=fake.date_of_birth(),
+                gender="M",
+            )
+            user2 = user_model.objects.create_user(
+                email=fake.unique.email(),
+                password="pw",
+                name=fake.name(),
+                nickname=fake.pystr(max_chars=10),
+                phone_number=fake.unique.phone_number(),
+                birthday=fake.date_of_birth(),
+                gender="M",
+            )
+            # 24년도 5월 탈퇴한 유저 1명
+            Withdrawals.objects.create(user=user2, reason="OTHER", reason_detail="test", due_date=date(2024, 5, 30))
+
+        with freeze_time("2025-09-12"):
+            # 25년 9월 가입한 유저 1명
+            user3 = user_model.objects.create_user(
+                email=fake.unique.email(),
+                password="pw",
+                name=fake.name(),
+                nickname=fake.pystr(max_chars=10),
+                phone_number=fake.unique.phone_number(),
+                birthday=fake.date_of_birth(),
+                gender="M",
+            )
+            # 25년 9월 탈퇴한 유저 1명
+            Withdrawals.objects.create(user=user3, reason="OTHER", reason_detail="test", due_date=date(2025, 9, 30))
+
+        cls.signup_url = reverse("admin_user:dashboard-signup-trends")
+        cls.withdrawal_url = reverse("admin_user:dashboard-withdrawal-trends")
+
+    def test_signup_trends_success(self) -> None:
+        """대시보드 가입 추세 집계 API 데이터 반환 테스트"""
+        self.client.force_authenticate(user=self.superuser)
+
+        # 월 단위 조회 테스트
+        response_monthly = self.client.get(self.signup_url, {"period": "monthly"})
+        self.assertEqual(response_monthly.status_code, status.HTTP_200_OK)
+        expected_monthly_data = {
+            "2023-09": 1,
+            "2024-05": 2,
+            "2025-09": 4,
+        }
+        self.assertEqual(response_monthly.data, expected_monthly_data)
+
+        # 연 단위 조회 테스트
+        response_yearly = self.client.get(self.signup_url, {"period": "yearly"})
+        self.assertEqual(response_yearly.status_code, status.HTTP_200_OK)
+        expected_yearly_data = {
+            "2023": 1,
+            "2024": 2,
+            "2025": 4,
+        }
+        self.assertEqual(response_yearly.data, expected_yearly_data)
+
+    def test_withdrawal_trends_success(self) -> None:
+        """대시보드 탈퇴 추세 집계 API 데이터 반환 테스트"""
+        self.client.force_authenticate(user=self.superuser)
+
+        response_monthly = self.client.get(self.withdrawal_url, {"period": "monthly"})
+        self.assertEqual(response_monthly.status_code, status.HTTP_200_OK)
+        excepted_data = {
+            "2024-05": 1,
+            "2025-09": 1,
+        }
+        self.assertEqual(response_monthly.data, excepted_data)
+
+    def test_trends_permission_denied(self) -> None:
+        """권한이 없는 유저 (일반유저)가 대시보드 API 접근시 403 에러 반환 테스트"""
+        self.client.force_authenticate(user=self.general_user)
+
+        sighup_response = self.client.get(self.signup_url)
+        withdrawals_response = self.client.get(self.withdrawal_url)
+
+        self.assertEqual(sighup_response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(withdrawals_response.status_code, status.HTTP_403_FORBIDDEN)

--- a/apps/users/urls/admin_urls.py
+++ b/apps/users/urls/admin_urls.py
@@ -1,6 +1,10 @@
 from django.urls import URLPattern, URLResolver, include, path
 from rest_framework.routers import DefaultRouter
 
+from apps.users.views.admin_dashboard_view import (
+    SignUpTrendAPIView,
+    WithdrawalTrendAPIView,
+)
 from apps.users.views.admin_views import UserAdminViewSet, UserPermissionUpdateAPIView
 from apps.users.views.admin_withdrawal_view import WithdrawalAdminViewSet
 
@@ -12,6 +16,8 @@ router.register("users", UserAdminViewSet, basename="users")
 router.register("withdrawals", WithdrawalAdminViewSet, basename="admin-withdrawal")
 
 urlpatterns: list[URLPattern | URLResolver] = [
-    path("users/<uuid:user_uuid>/permission", UserPermissionUpdateAPIView.as_view(), name="user_permissions"),
+    path("dashboard/signup-trends/", SignUpTrendAPIView.as_view(), name="dashboard-signup-trends"),
+    path("dashboard/withdrawal-trends/", WithdrawalTrendAPIView.as_view(), name="dashboard-withdrawal-trends"),
+    path("users/<uuid:user_uuid>/permission/", UserPermissionUpdateAPIView.as_view(), name="user_permissions"),
     path("", include(router.urls)),
 ]

--- a/apps/users/views/admin_dashboard_view.py
+++ b/apps/users/views/admin_dashboard_view.py
@@ -7,7 +7,10 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.users.services.admin_dashboard_services import AdminDashboardService, Period
+from apps.users.services.admin_dashboard_services import (
+    AdminDashboardPeriod,
+    AdminDashboardService,
+)
 
 
 @extend_schema(
@@ -34,12 +37,14 @@ class SignUpTrendAPIView(APIView):
 
     def get(self, request: Request) -> Response:
         period_str = request.query_params.get("period", "monthly")
-        if period_str not in ["monthly", "yearly"]:
+
+        try:
+            period = AdminDashboardPeriod(period_str)
+        except ValueError:
             return Response(
                 {"error": "period는 'monthly' 또는 'yearly'만 가능합니다."}, status=status.HTTP_400_BAD_REQUEST
             )
 
-        period = cast(Period, period_str)
         data = AdminDashboardService.get_signup_trends(period=period)
         return Response(data)
 
@@ -68,11 +73,13 @@ class WithdrawalTrendAPIView(APIView):
 
     def get(self, request: Request) -> Response:
         period_str = request.query_params.get("period", "monthly")
-        if period_str not in ["monthly", "yearly"]:
+
+        try:
+            period = AdminDashboardPeriod(period_str)
+        except ValueError:
             return Response(
                 {"error": "period는 'monthly' 또는 'yearly'만 가능합니다."}, status=status.HTTP_400_BAD_REQUEST
             )
 
-        period = cast(Period, period_str)
         data = AdminDashboardService.get_withdrawals_trends(period=period)
         return Response(data)

--- a/apps/users/views/admin_dashboard_view.py
+++ b/apps/users/views/admin_dashboard_view.py
@@ -1,0 +1,78 @@
+from typing import Callable, cast
+
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+from rest_framework import status
+from rest_framework.permissions import IsAdminUser
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.users.services.admin_dashboard_services import AdminDashboardService, Period
+
+
+@extend_schema(
+    tags=["관리자 페이지 API - 대시보드"],
+    summary="회원가입 추세 조회",
+    description="연, 월 단위로 회원가입 추세를 조회합니다.",
+    parameters=[
+        OpenApiParameter(
+            name="period",
+            type=str,
+            description="조회 기간 단위, 'monthly', 'yearly'를 입력합니다.",
+            required=False,
+            default="monthly",
+            enum=["monthly", "yearly"],
+        )
+    ],
+    responses={200: {"description": "성공", "example": {"2025-08": 10, "2025-09": 15}}},
+)
+class SignUpTrendAPIView(APIView):
+    permission_classes = [IsAdminUser]
+    """
+    월 단위, 연 단위 회원가입 추세 데이터를 반환하는 API
+    """
+
+    def get(self, request: Request) -> Response:
+        period_str = request.query_params.get("period", "monthly")
+        if period_str not in ["monthly", "yearly"]:
+            return Response(
+                {"error": "period는 'monthly' 또는 'yearly'만 가능합니다."}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        period = cast(Period, period_str)
+        data = AdminDashboardService.get_signup_trends(period=period)
+        return Response(data)
+
+
+@extend_schema(
+    tags=["관리자 페이지 API - 대시보드"],
+    summary="회원탈퇴 추세 조회",
+    description="연, 월 단위로 회원탈퇴 추세를 조회합니다.",
+    parameters=[
+        OpenApiParameter(
+            name="period",
+            type=str,
+            description="조회 기간 단위, 'monthly', 'yearly'를 입력합니다.",
+            required=False,
+            default="monthly",
+            enum=["monthly", "yearly"],
+        )
+    ],
+    responses={200: {"description": "성공", "example": {"2025-07": 2, "2025-08": 5}}},
+)
+class WithdrawalTrendAPIView(APIView):
+    permission_classes = [IsAdminUser]
+    """
+    월 단위, 연 단위 회원탈퇴 추세 데이터를 반환하는 API
+    """
+
+    def get(self, request: Request) -> Response:
+        period_str = request.query_params.get("period", "monthly")
+        if period_str not in ["monthly", "yearly"]:
+            return Response(
+                {"error": "period는 'monthly' 또는 'yearly'만 가능합니다."}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        period = cast(Period, period_str)
+        data = AdminDashboardService.get_withdrawals_trends(period=period)
+        return Response(data)

--- a/poetry.lock
+++ b/poetry.lock
@@ -4186,4 +4186,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "0ec009ccd05593f6d6211abe580eed79c876ebbb32420a169dd6afba4115df45"
+content-hash = "7a26a50b2dd1184a75f8303b7106069d93ad91e0f5f66b9cb04445ce1ae50ad8"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1572,6 +1572,36 @@ offline = ["drf-spectacular-sidecar"]
 sidecar = ["drf-spectacular-sidecar"]
 
 [[package]]
+name = "faker"
+version = "37.8.0"
+description = "Faker is a Python package that generates fake data for you."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "faker-37.8.0-py3-none-any.whl", hash = "sha256:b08233118824423b5fc239f7dd51f145e7018082b4164f8da6a9994e1f1ae793"},
+    {file = "faker-37.8.0.tar.gz", hash = "sha256:090bb5abbec2b30949a95ce1ba6b20d1d0ed222883d63483a0d4be4a970d6fb8"},
+]
+
+[package.dependencies]
+tzdata = "*"
+
+[[package]]
+name = "freezegun"
+version = "1.5.5"
+description = "Let your Python tests travel through time"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "freezegun-1.5.5-py3-none-any.whl", hash = "sha256:cd557f4a75cf074e84bc374249b9dd491eaeacd61376b9eb3c423282211619d2"},
+    {file = "freezegun-1.5.5.tar.gz", hash = "sha256:ac7742a6cc6c25a2c35e9292dfd554b897b517d2dec26891a2e8debf205cb94a"},
+]
+
+[package.dependencies]
+python-dateutil = ">=2.7"
+
+[[package]]
 name = "frozenlist"
 version = "1.7.0"
 description = "A list-like structure which implements collections.abc.MutableSequence"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ dependencies = [
     "celery (>=5.5.3,<6.0.0)",
     "google-generativeai (>=0.8.5,<0.9.0)",
     "google-genai (>=1.38.0,<2.0.0)",
+    "freezegun (>=1.5.5,<2.0.0)",
+    "faker (>=37.8.0,<38.0.0)",
 ]
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
회원관리 대시보드 API 구현, 회원 가입 및 탈퇴 추세 집계 기능 구현

관련 이슈: #105

## ✅ PR 요약
- 관련 이슈 번호: #105
- 작업 요약: 회원관리 대시보드 API 구현, 회원 가입 및 탈퇴 추세 집계 기능 구현

## 📄 상세 내용
- [x] 회원관리 대시보드, 가입 및 탈퇴 추세 집계 service, view 작성
- [x] 대시보드 TEST CODE 작성
- [x] TEST를 위한 라이브러리 Faker 라이브러리 설치

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
