### PR TITLE
스터디 그룹 멤버 강퇴 API

### DIFF
--- a/apps/studies/services/delete_member_service.py
+++ b/apps/studies/services/delete_member_service.py
@@ -20,9 +20,9 @@ class DeleteMemberService:
         """
         return self.group.members.through.objects.get(user=self.target, study_group=self.group).is_leader
 
-    def studygroup_withdraw_service(self) -> None:
+    def groupmember_delete_service(self) -> None:
         """
-        스터디 그룹 탈퇴 기능
+        스터디 그룹 탈퇴 및 강퇴 기능
         """
         if self.check_leader():
             raise PermissionDenied("그룹 리더는 리더 위임 후 그룹을 탈퇴할 수 있습니다.")

--- a/apps/studies/services/delete_member_service.py
+++ b/apps/studies/services/delete_member_service.py
@@ -20,10 +20,18 @@ class DeleteMemberService:
         """
         return self.group.members.through.objects.get(user=self.target, study_group=self.group).is_leader
 
-    def groupmember_delete_service(self) -> None:
+    def withdraw_studygroup(self) -> None:
         """
-        스터디 그룹 탈퇴 및 강퇴 기능
+        스터디 그룹 탈퇴 기능
         """
         if self.check_leader():
             raise PermissionDenied("그룹 리더는 리더 위임 후 그룹을 탈퇴할 수 있습니다.")
+        self.group.members.remove(self.target)
+
+    def kick_groupmember(self) -> None:
+        """
+        스터디 그룹 강퇴 기능
+        """
+        if self.check_leader():
+            raise PermissionDenied("본인을 강퇴 할 수 없습니다. 리더 위임 후 그룹 탈퇴로 진행 할 수 있습니다.")
         self.group.members.remove(self.target)

--- a/apps/studies/tests/test_kick_groupmember.py
+++ b/apps/studies/tests/test_kick_groupmember.py
@@ -1,0 +1,105 @@
+import logging
+from datetime import datetime
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.core.tests.mixins.test_user_mixins import TestUserMixin
+from apps.lectures.models import Lecture
+from apps.lectures.models.crawled_lectures import DifficultyChoices, PlatformChoices
+from apps.studies.models import GroupMember, StudyGroup
+from apps.studies.serializers.study_group import StudyGroupCreateUpdateSerializer
+
+logger = logging.getLogger(__name__)
+
+
+class KickGroupMemberAPITest(APITestCase, TestUserMixin):
+    """
+    스터디 그룹 리더가 같은 그룹원을 강퇴하는 API 테스트
+    """
+
+    def setUp(self) -> None:
+        # 테스트를 위한 유저 생성
+        self.leader = self._create_test_user()  # 스터디 그룹 리더
+        self.member = self._create_test_user(
+            email="kimshineday@test.com", nickname="김빛날", phone_number="01098765432"
+        )  # 스터디 그룹원
+        self.test_user = self._create_test_user(
+            email="test@test.com", nickname="test", phone_number="01000000000"
+        )  # 일반 유저
+
+        # 스터디 그룹 생성
+        self.lecture = Lecture.objects.create(
+            title="test lecture",
+            instructor="김인직",
+            average_rating=4.23,
+            duration=20,
+            difficulty=DifficultyChoices.NORMAL,
+            description="testtest",
+            platform=PlatformChoices.INFLEARN,
+            original_price=40000,
+            discount_price=32000,
+            url_link="https://ozcoding.site/lectures/1",
+        )
+        self.data = {
+            "name": "스터디 그룹 멤버 강퇴 테스트",
+            "introduction": "기본 데이터 생성",
+            "max_headcount": 3,
+            "start_at": datetime(2025, 10, 15),
+            "end_at": datetime(2025, 10, 30),
+            "lectures": [self.lecture.id],
+        }
+        self.group = StudyGroupCreateUpdateSerializer(data=self.data)
+        self.assertTrue(self.group.is_valid(raise_exception=True))
+        self.group.save(user=self.leader)
+        self.study_group_member = GroupMember.objects.create(
+            user=self.member, study_group=StudyGroup.objects.get(uuid=self.group.data["uuid"])
+        )
+
+    def test_delete_fail_1(self) -> None:
+        """
+        리더 권한이 없는 경우 fail case
+        """
+        self.url = reverse(
+            "kick_group_member", kwargs={"group_uuid": self.group.data["uuid"], "member_uuid": self.leader.uuid}
+        )
+        self.client.force_authenticate(user=self.member)  # 그룹원이 아닌 사람
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        logger.debug(response.data)
+
+    def test_delete_fail_2(self) -> None:
+        """
+        리더인 자기 자신을 강퇴하려는 경우 fail case
+        """
+        self.url = reverse(
+            "kick_group_member", kwargs={"group_uuid": self.group.data["uuid"], "member_uuid": self.leader.uuid}
+        )
+        self.client.force_authenticate(user=self.leader)  # 스터디 그룹 리더
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        logger.debug(response.data)
+
+    def test_delete_fail_3(self) -> None:
+        """
+        강퇴하려는 사람이 같은 스터디 그룹원이 아닌 경우 fail case
+        """
+        self.url = reverse(
+            "kick_group_member", kwargs={"group_uuid": self.group.data["uuid"], "member_uuid": self.test_user.uuid}
+        )
+        self.client.force_authenticate(user=self.leader)  # 스터디 그룹 리더
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        logger.debug(response.data)
+
+    def test_delete_success(self) -> None:
+        """
+        success case!
+        """
+        self.url = reverse(
+            "kick_group_member", kwargs={"group_uuid": self.group.data["uuid"], "member_uuid": self.member.uuid}
+        )
+        self.client.force_authenticate(user=self.leader)  # 스터디 그룹원
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/apps/studies/urls/study_group.py
+++ b/apps/studies/urls/study_group.py
@@ -1,6 +1,9 @@
 from django.urls import path
 
-from apps.studies.views.group_member_delete_view import WithdrawGroupMemberView
+from apps.studies.views.group_member_delete_view import (
+    KickGroupMemberView,
+    WithdrawGroupMemberView,
+)
 from apps.studies.views.leader_delegate_view import StudyGroupLeaderDelegateView
 from apps.studies.views.study_group_create_view import CreateStudyGroupView
 from apps.studies.views.study_group_update_view import UpdateStudyGroupView
@@ -10,4 +13,5 @@ urlpatterns = [
     path("/<uuid:group_uuid>", UpdateStudyGroupView.as_view(), name="update_study_group"),
     path("/<uuid:group_uuid>/delegate", StudyGroupLeaderDelegateView.as_view(), name="leader_delegate"),
     path("/<uuid:group_uuid>/withdraw", WithdrawGroupMemberView.as_view(), name="withdraw_study_group"),
+    path("/<uuid:group_uuid>/kick/<uuid:member_uuid>", KickGroupMemberView.as_view(), name="kick_group_member"),
 ]

--- a/apps/studies/views/group_member_delete_view.py
+++ b/apps/studies/views/group_member_delete_view.py
@@ -1,5 +1,6 @@
 from typing import cast
 
+from django.core.exceptions import ObjectDoesNotExist
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
@@ -8,7 +9,10 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.studies.models import StudyGroup
-from apps.studies.permissions import IsStudyGroupMemberPermission
+from apps.studies.permissions import (
+    IsStudyGroupLeaderPermission,
+    IsStudyGroupMemberPermission,
+)
 from apps.studies.services.delete_member_service import DeleteMemberService
 from apps.users.models import User
 
@@ -30,5 +34,28 @@ class WithdrawGroupMemberView(APIView):
         self.check_object_permissions(request, group)
         user = cast(User, request.user)
         delete_member = DeleteMemberService(group=group, user=user)
-        delete_member.studygroup_withdraw_service()
+        delete_member.groupmember_delete_service()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class KickGroupMemberView(APIView):
+    """
+    스터디 그룹 리더가 같은 그룹원을 강퇴 요청시 실행되는 로직
+    """
+
+    permission_classes = [IsStudyGroupLeaderPermission]
+
+    @extend_schema(
+        summary="스터디 그룹 멤버 강퇴 API",
+        description="스터디 그룹의 리더는 같은 그룹원 중 특정 멤버를 선택하여 강퇴 할 수 있습니다.",
+        tags=["Study Group"],
+    )
+    def delete(self, request: Request, group_uuid: str, member_uuid: str) -> Response:
+        group = get_object_or_404(StudyGroup, uuid=group_uuid)
+        try:
+            user = group.members.through.objects.get(study_group=group, user__uuid=member_uuid)
+        except ObjectDoesNotExist:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+        delete_member = DeleteMemberService(group=group, user=user.user)
+        delete_member.groupmember_delete_service()
         return Response(status=status.HTTP_204_NO_CONTENT)

--- a/apps/studies/views/group_member_delete_view.py
+++ b/apps/studies/views/group_member_delete_view.py
@@ -34,7 +34,7 @@ class WithdrawGroupMemberView(APIView):
         self.check_object_permissions(request, group)
         user = cast(User, request.user)
         delete_member = DeleteMemberService(group=group, user=user)
-        delete_member.groupmember_delete_service()
+        delete_member.withdraw_studygroup()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
@@ -57,5 +57,5 @@ class KickGroupMemberView(APIView):
         except ObjectDoesNotExist:
             return Response(status=status.HTTP_404_NOT_FOUND)
         delete_member = DeleteMemberService(group=group, user=user.user)
-        delete_member.groupmember_delete_service()
+        delete_member.kick_groupmember()
         return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #211 
- 작업 요약: 스터디 그룹 멤버 강퇴 API 기능 구현

## 📄 상세 내용
- [ ] 스터디 그룹 리더 검증 (스터디 그룹 리더 퍼미션 활용)
- [ ] 선택한 그룹원이 같은 그룹원인지 확인 필요
- [ ] GroupMember 에서 해당 데이터 삭제
  - [ ] 스터디 그룹 탈퇴에서 사용하는 삭제 코드 사용 (함수 이름 변경 groupmember_delete_service)
- [ ] test code 작성

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
