### PR TITLE
✨ feat: 스터디 공고 북마크 기능 구현

### DIFF
--- a/apps/recruitments/managers/bookmark_managers.py
+++ b/apps/recruitments/managers/bookmark_managers.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.db import models
+
+if TYPE_CHECKING:   # pragma: no cover
+    from apps.recruitments.models.recruitment_bookmarks import RecruitmentBookmark
+    from apps.recruitments.models.recruitments import Recruitment
+    from apps.users.models import User
+
+
+class RecruitmentBookmarkManager(models.Manager["RecruitmentBookmark"]):
+    def add_bookmark(self, user: "User", recruitment: "Recruitment") -> tuple["RecruitmentBookmark", bool]:
+        bookmark, created = self.get_or_create(user=user, recruitment=recruitment)
+        return bookmark, created
+
+    def remove_bookmark(self, user: "User", recruitment: "Recruitment") -> tuple[int, dict[str, int]]:
+        deleted_count, _ = self.filter(user=user, recruitment=recruitment).delete()
+        return deleted_count, _

--- a/apps/recruitments/managers/bookmark_managers.py
+++ b/apps/recruitments/managers/bookmark_managers.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from django.db import models
 
-if TYPE_CHECKING:   # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from apps.recruitments.models.recruitment_bookmarks import RecruitmentBookmark
     from apps.recruitments.models.recruitments import Recruitment
     from apps.users.models import User

--- a/apps/recruitments/managers/managers_list.py
+++ b/apps/recruitments/managers/managers_list.py
@@ -7,7 +7,7 @@ from django.db import models
 from django.db.models import Count, OuterRef, Subquery
 
 # 순환참조를 하지 않고 범용성을 위해 _T 사용
-if TYPE_CHECKING:   # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
     from apps.recruitments.models import Recruitment
     from apps.recruitments.models.recruitment_images import RecruitmentImage
     from apps.users.models import User
@@ -39,9 +39,10 @@ class RecruitmentListQuerySet(models.QuerySet["Recruitment"]):
         """특정 사용자가 북마크한 공고 목록을 반환합니다."""
         return self.filter(bookmark_users=user).recm_list_queryset()
 
+
 # Mypy가 분석할 때 동적할당은 안잡아서 변수에 할당해서 정적클래스로 검사하고 동적으로 사용함
 _RecruitmentListManager = models.Manager.from_queryset(RecruitmentListQuerySet)
-if TYPE_CHECKING:   # pragma: no cover
+if TYPE_CHECKING:  # pragma: no cover
 
     class RecruitmentListManager(_RecruitmentListManager["Recruitment"]):
         pass

--- a/apps/recruitments/managers/managers_list.py
+++ b/apps/recruitments/managers/managers_list.py
@@ -7,9 +7,10 @@ from django.db import models
 from django.db.models import Count, OuterRef, Subquery
 
 # 순환참조를 하지 않고 범용성을 위해 _T 사용
-if TYPE_CHECKING:
+if TYPE_CHECKING:   # pragma: no cover
     from apps.recruitments.models import Recruitment
     from apps.recruitments.models.recruitment_images import RecruitmentImage
+    from apps.users.models import User
 
 
 class RecruitmentListQuerySet(models.QuerySet["Recruitment"]):
@@ -34,10 +35,13 @@ class RecruitmentListQuerySet(models.QuerySet["Recruitment"]):
         )
         return optimized_queryset
 
+    def get_bookmarked_recruitments(self, user: "User") -> Self:
+        """특정 사용자가 북마크한 공고 목록을 반환합니다."""
+        return self.filter(bookmark_users=user).recm_list_queryset()
 
 # Mypy가 분석할 때 동적할당은 안잡아서 변수에 할당해서 정적클래스로 검사하고 동적으로 사용함
 _RecruitmentListManager = models.Manager.from_queryset(RecruitmentListQuerySet)
-if TYPE_CHECKING:
+if TYPE_CHECKING:   # pragma: no cover
 
     class RecruitmentListManager(_RecruitmentListManager["Recruitment"]):
         pass

--- a/apps/recruitments/models/recruitment_bookmarks.py
+++ b/apps/recruitments/models/recruitment_bookmarks.py
@@ -1,6 +1,7 @@
 from django.db import models
 
 from apps.core.models.base import BaseModel
+from apps.recruitments.managers.bookmark_managers import RecruitmentBookmarkManager
 from apps.recruitments.models.recruitments import Recruitment
 from apps.users.models.user import User
 
@@ -11,6 +12,8 @@ class RecruitmentBookmark(BaseModel):
 
     user = models.ForeignKey(User, on_delete=models.CASCADE, help_text="북마크한 유저 ID")
     recruitment = models.ForeignKey(Recruitment, on_delete=models.CASCADE, help_text="공고 ID")
+
+    objects = RecruitmentBookmarkManager()
 
     class Meta:
         db_table = "recruitment_bookmarks"

--- a/apps/recruitments/serializers/bookmark_serializers.py
+++ b/apps/recruitments/serializers/bookmark_serializers.py
@@ -1,0 +1,31 @@
+from rest_framework import serializers
+
+from ..models import Recruitment
+from .recruitments_serializers import LectureSerializer, TagSerializer
+
+
+class MyBookmarkedRecruitmentListSerializer(serializers.ModelSerializer[Recruitment]):
+    lectures = LectureSerializer(many=True, read_only=True, source="study_group.lectures")
+    tags = TagSerializer(many=True, read_only=True)
+    thumbnail_image_url = serializers.SerializerMethodField()
+    bookmark_count = serializers.IntegerField(source="bookmark_users.count")
+
+    class Meta:
+        model = Recruitment
+        fields = [
+            "uuid",
+            "title",
+            "thumbnail_image_url",
+            "expected_headcount",
+            "lectures",
+            "tags",
+            "close_at",
+            "views_count",
+            "bookmark_count",
+        ]
+
+    def get_thumbnail_image_url(self, obj: Recruitment) -> str | None:
+        first_image = obj.images.first()
+        if first_image:
+            return first_image.img_url
+        return None

--- a/apps/recruitments/services/bookmark_services.py
+++ b/apps/recruitments/services/bookmark_services.py
@@ -1,0 +1,27 @@
+from django.db.models.query import QuerySet
+from rest_framework.exceptions import NotFound
+
+from apps.recruitments.models import Recruitment, RecruitmentBookmark
+from apps.users.models import User
+
+
+class BookmarkService:
+    def _get_recruitment(self, recruitment_id: int) -> Recruitment:
+        try:
+            return Recruitment.objects.get(id=recruitment_id)
+        except Recruitment.DoesNotExist:
+            raise NotFound("해당 스터디 구인 공고는 존재하지 않습니다.")
+
+    def add(self, user: User, recruitment_id: int) -> tuple["RecruitmentBookmark", bool]:
+        recruitment = self._get_recruitment(recruitment_id)
+        bookmark, created = RecruitmentBookmark.objects.add_bookmark(user=user, recruitment=recruitment)
+        return bookmark, created
+
+    def remove(self, user: User, recruitment_id: int) -> None:
+        recruitment = self._get_recruitment(recruitment_id)
+        deleted_count, _ = RecruitmentBookmark.objects.remove_bookmark(user=user, recruitment=recruitment)
+        if deleted_count == 0:
+            raise NotFound("북마크 내역이 존재하지 않습니다.")
+
+    def get_bookmarked_list(self, user: User) -> QuerySet[Recruitment]:
+        return Recruitment.object_list.get_bookmarked_recruitments(user=user)

--- a/apps/recruitments/services/bookmark_services.py
+++ b/apps/recruitments/services/bookmark_services.py
@@ -1,3 +1,5 @@
+from uuid import UUID
+
 from django.db.models.query import QuerySet
 from rest_framework.exceptions import NotFound
 
@@ -6,22 +8,22 @@ from apps.users.models import User
 
 
 class BookmarkService:
-    def _get_recruitment(self, recruitment_id: int) -> Recruitment:
+    def _get_recruitment(self, recruitment_uuid: UUID) -> Recruitment:
         try:
-            return Recruitment.objects.get(id=recruitment_id)
+            return Recruitment.objects.get(uuid=recruitment_uuid)
         except Recruitment.DoesNotExist:
             raise NotFound("해당 스터디 구인 공고는 존재하지 않습니다.")
 
-    def add(self, user: User, recruitment_id: int) -> tuple["RecruitmentBookmark", bool]:
-        recruitment = self._get_recruitment(recruitment_id)
+    def add(self, user: User, recruitment_uuid: UUID) -> tuple["RecruitmentBookmark", bool]:
+        recruitment = self._get_recruitment(recruitment_uuid)
         bookmark, created = RecruitmentBookmark.objects.add_bookmark(user=user, recruitment=recruitment)
         return bookmark, created
 
-    def remove(self, user: User, recruitment_id: int) -> None:
-        recruitment = self._get_recruitment(recruitment_id)
+    def remove(self, user: User, recruitment_uuid: UUID) -> None:
+        recruitment = self._get_recruitment(recruitment_uuid)
         deleted_count, _ = RecruitmentBookmark.objects.remove_bookmark(user=user, recruitment=recruitment)
         if deleted_count == 0:
-            raise NotFound("북마크 내역이 존재하지 않습니다.")
+            raise NotFound("삭제할 북마크를 찾을 수 없습니다.")
 
     def get_bookmarked_list(self, user: User) -> QuerySet[Recruitment]:
         return Recruitment.object_list.get_bookmarked_recruitments(user=user)

--- a/apps/recruitments/tests/test_bookmarks.py
+++ b/apps/recruitments/tests/test_bookmarks.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import date, timedelta
 
 from django.urls import reverse
@@ -72,7 +73,7 @@ class BookmarkAPITestCase(APITestCase):
     def test_add_bookmark_success(self) -> None:
         """인증된 사용자가 북마크 추가 시 201 응답 및 DB 레코드 확인"""
         self.client.force_authenticate(user=self.user2)
-        url = reverse("recruitment-bookmark", kwargs={"recruitment_id": self.recruitment1.id})
+        url = reverse("recruitment-bookmark", kwargs={"recruitment_uuid": self.recruitment1.uuid})
         response = self.client.post(url)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -80,7 +81,7 @@ class BookmarkAPITestCase(APITestCase):
 
     def test_add_bookmark_unauthenticated(self) -> None:
         """인증되지 않은 사용자의 북마크 추가 요청 시 401 응답 확인"""
-        url = reverse("recruitment-bookmark", kwargs={"recruitment_id": self.recruitment1.id})
+        url = reverse("recruitment-bookmark", kwargs={"recruitment_uuid": self.recruitment1.uuid})
         response = self.client.post(url)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
@@ -90,7 +91,7 @@ class BookmarkAPITestCase(APITestCase):
         # 먼저 북마크를 추가
         RecruitmentBookmark.objects.create(user=self.user2, recruitment=self.recruitment1)
 
-        url = reverse("recruitment-bookmark", kwargs={"recruitment_id": self.recruitment1.id})
+        url = reverse("recruitment-bookmark", kwargs={"recruitment_uuid": self.recruitment1.uuid})
         response = self.client.post(url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -99,8 +100,8 @@ class BookmarkAPITestCase(APITestCase):
     def test_add_bookmark_nonexistent_recruitment(self) -> None:
         """존재하지 않는 공고에 북마크 요청 시 404 응답 확인"""
         self.client.force_authenticate(user=self.user2)
-        non_existent_id = 9999
-        url = reverse("recruitment-bookmark", kwargs={"recruitment_id": non_existent_id})
+        non_existent_uuid = uuid.uuid4()
+        url = reverse("recruitment-bookmark", kwargs={"recruitment_uuid": non_existent_uuid})
         response = self.client.post(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
@@ -112,7 +113,7 @@ class BookmarkAPITestCase(APITestCase):
         # 먼저 북마크를 추가
         RecruitmentBookmark.objects.create(user=self.user2, recruitment=self.recruitment1)
 
-        url = reverse("recruitment-bookmark", kwargs={"recruitment_id": self.recruitment1.id})
+        url = reverse("recruitment-bookmark", kwargs={"recruitment_uuid": self.recruitment1.uuid})
         response = self.client.delete(url)
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
@@ -121,7 +122,7 @@ class BookmarkAPITestCase(APITestCase):
     def test_remove_bookmark_not_bookmarked(self) -> None:
         """북마크하지 않은 공고에 삭제 요청 시 404 응답 확인"""
         self.client.force_authenticate(user=self.user2)
-        url = reverse("recruitment-bookmark", kwargs={"recruitment_id": self.recruitment1.id})
+        url = reverse("recruitment-bookmark", kwargs={"recruitment_uuid": self.recruitment1.uuid})
         response = self.client.delete(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 

--- a/apps/recruitments/tests/test_bookmarks.py
+++ b/apps/recruitments/tests/test_bookmarks.py
@@ -1,0 +1,159 @@
+from datetime import date, timedelta
+
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from apps.lectures.models import Lecture
+from apps.recruitments.models import Recruitment, RecruitmentBookmark
+from apps.studies.models import StudyGroup
+from apps.users.models import User
+
+
+class BookmarkAPITestCase(APITestCase):
+    def setUp(self) -> None:
+        """테스트에 필요한 초기 데이터 설정"""
+        self.user1 = User.objects.create_user(
+            email="user1@test.com",
+            password="password123",
+            nickname="테스터1",
+            name="김테스터",
+            phone_number="010-1111-1111",
+            gender="M",
+            birthday=date(2000, 1, 1),
+        )
+        self.user2 = User.objects.create_user(
+            email="user2@test.com",
+            password="password123",
+            nickname="테스터2",
+            name="이테스터",
+            phone_number="010-2222-2222",
+            gender="F",
+            birthday=date(2000, 1, 1),
+        )
+
+        self.lecture1 = Lecture.objects.create(
+            title="강의1",
+            instructor="강사1",
+            platform="플랫폼1",
+            duration=100,
+            difficulty="normal",
+            description="테스트용 강의 설명",
+            url_link="http://test.com/lecture1",
+        )
+        self.study_group1 = StudyGroup.objects.create(
+            name="스터디그룹1",
+            max_headcount=5,
+            start_at=timezone.now(),
+            end_at=timezone.now() + timedelta(days=30),
+        )
+        self.study_group1.lectures.add(self.lecture1)
+
+        self.recruitment1 = Recruitment.objects.create(
+            author=self.user1,
+            study_group=self.study_group1,
+            title="공고1",
+            content="내용1",
+            expected_headcount=5,
+            estimated_fee=10000,
+        )
+        self.recruitment2 = Recruitment.objects.create(
+            author=self.user1,
+            study_group=self.study_group1,
+            title="공고2",
+            content="내용2",
+            expected_headcount=5,
+            estimated_fee=20000,
+        )
+
+    # --- REQ-RECM-010: 북마크 추가 테스트 --- #
+
+    def test_add_bookmark_success(self) -> None:
+        """인증된 사용자가 북마크 추가 시 201 응답 및 DB 레코드 확인"""
+        self.client.force_authenticate(user=self.user2)
+        url = reverse("recruitment-bookmark", kwargs={"recruitment_id": self.recruitment1.id})
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertTrue(RecruitmentBookmark.objects.filter(user=self.user2, recruitment=self.recruitment1).exists())
+
+    def test_add_bookmark_unauthenticated(self) -> None:
+        """인증되지 않은 사용자의 북마크 추가 요청 시 401 응답 확인"""
+        url = reverse("recruitment-bookmark", kwargs={"recruitment_id": self.recruitment1.id})
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_add_bookmark_already_exists(self) -> None:
+        """이미 북마크한 공고에 재요청 시 200 응답 확인"""
+        self.client.force_authenticate(user=self.user2)
+        # 먼저 북마크를 추가
+        RecruitmentBookmark.objects.create(user=self.user2, recruitment=self.recruitment1)
+
+        url = reverse("recruitment-bookmark", kwargs={"recruitment_id": self.recruitment1.id})
+        response = self.client.post(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(RecruitmentBookmark.objects.filter(user=self.user2, recruitment=self.recruitment1).count(), 1)
+
+    def test_add_bookmark_nonexistent_recruitment(self) -> None:
+        """존재하지 않는 공고에 북마크 요청 시 404 응답 확인"""
+        self.client.force_authenticate(user=self.user2)
+        non_existent_id = 9999
+        url = reverse("recruitment-bookmark", kwargs={"recruitment_id": non_existent_id})
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    # --- REQ-RECM-010: 북마크 삭제 테스트 --- #
+
+    def test_remove_bookmark_success(self) -> None:
+        """인증된 사용자가 북마크 삭제 시 204 응답 및 DB 레코드 삭제 확인"""
+        self.client.force_authenticate(user=self.user2)
+        # 먼저 북마크를 추가
+        RecruitmentBookmark.objects.create(user=self.user2, recruitment=self.recruitment1)
+
+        url = reverse("recruitment-bookmark", kwargs={"recruitment_id": self.recruitment1.id})
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(RecruitmentBookmark.objects.filter(user=self.user2, recruitment=self.recruitment1).exists())
+
+    def test_remove_bookmark_not_bookmarked(self) -> None:
+        """북마크하지 않은 공고에 삭제 요청 시 404 응답 확인"""
+        self.client.force_authenticate(user=self.user2)
+        url = reverse("recruitment-bookmark", kwargs={"recruitment_id": self.recruitment1.id})
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    # --- REQ-RECM-011: 북마크 목록 조회 테스트 --- #
+
+    def test_list_bookmarked_recruitments_success(self) -> None:
+        """인증된 사용자가 자신의 북마크 목록을 정확히 받는지 확인"""
+        self.client.force_authenticate(user=self.user2)
+        # user2가 recruitment1, recruitment2를 북마크
+        RecruitmentBookmark.objects.create(user=self.user2, recruitment=self.recruitment1)
+        RecruitmentBookmark.objects.create(user=self.user2, recruitment=self.recruitment2)
+
+        url = reverse("my-bookmark-list")
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 2)
+        # 최신순으로 정렬되므로 recruitment2가 먼저 나와야 함
+        self.assertEqual(response.data["results"][0]["title"], "공고2")
+        self.assertEqual(response.data["results"][1]["title"], "공고1")
+
+    def test_list_bookmarked_recruitments_empty(self) -> None:
+        """북마크가 없는 사용자의 경우 빈 목록이 반환되는지 확인"""
+        self.client.force_authenticate(user=self.user2)
+        url = reverse("my-bookmark-list")
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 0)
+
+    def test_list_bookmarked_recruitments_unauthenticated(self) -> None:
+        """인증되지 않은 사용자의 목록 조회 요청 시 401 응답 확인"""
+        url = reverse("my-bookmark-list")
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/apps/recruitments/urls/bookmark_urls.py
+++ b/apps/recruitments/urls/bookmark_urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from ..views.bookmark_views import (
+    BookmarkToggleView,
+    MyBookmarkedRecruitmentListView,
+)
+
+urlpatterns = [
+    path("me", MyBookmarkedRecruitmentListView.as_view(), name="my-bookmark-list"),
+    path("", BookmarkToggleView.as_view(), name="recruitment-bookmark"),
+]

--- a/apps/recruitments/urls/recruitments_urls.py
+++ b/apps/recruitments/urls/recruitments_urls.py
@@ -18,7 +18,7 @@ urlpatterns = [
     path("/<uuid:recruitment_uuid>/applications", ApplicationAPIView.as_view(), name="recruitment-applications"),
     # 북마크 기능 URL
     path("/bookmarks/me", MyBookmarkedRecruitmentListView.as_view(), name="my-bookmark-list"),
-    path("/<int:recruitment_id>/bookmarks/", BookmarkToggleView.as_view(), name="recruitment-bookmark"),
+    path("/<uuid:recruitment_uuid>/bookmarks/", BookmarkToggleView.as_view(), name="recruitment-bookmark"),
     # 상세 조회 URL은 다른 UUID를 사용하는 URL보다 뒤에 위치해야 의도치 않은 매칭을 피할 수 있습니다.
     path("/<uuid:recruitment_uuid>", RecruitmentDetailView.as_view(), name="recruitment-detail"),
 ]

--- a/apps/recruitments/urls/recruitments_urls.py
+++ b/apps/recruitments/urls/recruitments_urls.py
@@ -1,7 +1,11 @@
-from django.urls import path
+from django.urls import include, path
 
 from apps.applications.views.applications_views import ApplicationAPIView
 from apps.recruitments.views.attachments_views import RecruitmentFileView
+from apps.recruitments.views.bookmark_views import (
+    BookmarkToggleView,
+    MyBookmarkedRecruitmentListView,
+)
 from apps.recruitments.views.images_views import RecruitmentImageView
 from apps.recruitments.views.recruitment_detail_views import RecruitmentDetailView
 from apps.recruitments.views.recruitment_views import MyRecruitmentView, RecruitmentView
@@ -9,8 +13,12 @@ from apps.recruitments.views.recruitment_views import MyRecruitmentView, Recruit
 urlpatterns = [
     path("", RecruitmentView.as_view(), name="recruitment-list"),
     path("/me", MyRecruitmentView.as_view(), name="recruitment-mylist"),
-    path("/<uuid:recruitment_uuid>", RecruitmentDetailView.as_view(), name="recruitment-detail"),
     path("/attachments", RecruitmentFileView.as_view(), name="recruitment-attachments-upload"),
     path("/images", RecruitmentImageView.as_view(), name="recruitment-images-upload"),
     path("/<uuid:recruitment_uuid>/applications", ApplicationAPIView.as_view(), name="recruitment-applications"),
+    # 북마크 기능 URL
+    path("/bookmarks/me", MyBookmarkedRecruitmentListView.as_view(), name="my-bookmark-list"),
+    path("/<int:recruitment_id>/bookmarks/", BookmarkToggleView.as_view(), name="recruitment-bookmark"),
+    # 상세 조회 URL은 다른 UUID를 사용하는 URL보다 뒤에 위치해야 의도치 않은 매칭을 피할 수 있습니다.
+    path("/<uuid:recruitment_uuid>", RecruitmentDetailView.as_view(), name="recruitment-detail"),
 ]

--- a/apps/recruitments/views/bookmark_views.py
+++ b/apps/recruitments/views/bookmark_views.py
@@ -1,6 +1,8 @@
 from typing import Any, cast
+from uuid import UUID
 
-from rest_framework import status
+from drf_spectacular.utils import extend_schema, inline_serializer
+from rest_framework import serializers, status
 from rest_framework.exceptions import NotFound
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
@@ -18,23 +20,44 @@ from apps.users.models import User
 class BookmarkToggleView(APIView):
     permission_classes = [IsAuthenticated]
 
-    def post(self, request: Request, recruitment_id: int) -> Response:
+    @extend_schema(
+        tags=["스터디 구인 공고/북마크"],
+        summary="스터디 구인 공고 북마크 추가",
+        description="특정 스터디 구인 공고를 북마크합니다. 이미 북마크된 경우에도 성공으로 응답합니다.",
+        responses={
+            201: inline_serializer(name="BookmarkCreated", fields={"detail": serializers.CharField()}),
+            200: inline_serializer(name="BookmarkAlreadyExists", fields={"detail": serializers.CharField()}),
+            404: inline_serializer(name="RecruitmentNotFound", fields={"error": serializers.CharField()}),
+        },
+    )
+    def post(self, request: Request, recruitment_uuid: UUID) -> Response:
         service = BookmarkService()
+        # 서비스단에서 생성된 상세 예외 메시지를 그대로 클라이언트에게 전달한다.
         try:
-            _, created = service.add(user=cast(User, request.user), recruitment_id=recruitment_id)
+            _, created = service.add(user=cast(User, request.user), recruitment_uuid=recruitment_uuid)
             if created:
                 return Response({"detail": "북마크가 추가되었습니다."}, status=status.HTTP_201_CREATED)
             return Response({"detail": "이미 북마크되어 있습니다."}, status=status.HTTP_200_OK)
         except NotFound as e:
-            return Response({"detail": str(e)}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"error": str(e)}, status=status.HTTP_404_NOT_FOUND)
 
-    def delete(self, request: Request, recruitment_id: int) -> Response:
+    @extend_schema(
+        tags=["스터디 구인 공고/북마크"],
+        summary="스터디 구인 공고 북마크 삭제",
+        description="특정 스터디 구인 공고의 북마크를 해제합니다.",
+        responses={
+            204: None,
+            404: inline_serializer(name="BookmarkNotFound", fields={"error": serializers.CharField()}),
+        },
+    )
+    def delete(self, request: Request, recruitment_uuid: UUID) -> Response:
         service = BookmarkService()
+        # 서비스단에서 생성된 상세 예외 메시지를 그대로 클라이언트에게 전달한다.
         try:
-            service.remove(user=cast(User, request.user), recruitment_id=recruitment_id)
+            service.remove(user=cast(User, request.user), recruitment_uuid=recruitment_uuid)
             return Response(status=status.HTTP_204_NO_CONTENT)
         except NotFound as e:
-            return Response({"detail": str(e)}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"error": str(e)}, status=status.HTTP_404_NOT_FOUND)
 
 
 class MyBookmarkedRecruitmentListView(APIView):

--- a/apps/recruitments/views/bookmark_views.py
+++ b/apps/recruitments/views/bookmark_views.py
@@ -1,0 +1,52 @@
+from typing import Any, cast
+
+from rest_framework import status
+from rest_framework.exceptions import NotFound
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.core.paginators import DefaultCursorPagination
+from apps.recruitments.serializers.bookmark_serializers import (
+    MyBookmarkedRecruitmentListSerializer,
+)
+from apps.recruitments.services.bookmark_services import BookmarkService
+from apps.users.models import User
+
+
+class BookmarkToggleView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request: Request, recruitment_id: int) -> Response:
+        service = BookmarkService()
+        try:
+            _, created = service.add(user=cast(User, request.user), recruitment_id=recruitment_id)
+            if created:
+                return Response({"detail": "북마크가 추가되었습니다."}, status=status.HTTP_201_CREATED)
+            return Response({"detail": "이미 북마크되어 있습니다."}, status=status.HTTP_200_OK)
+        except NotFound as e:
+            return Response({"detail": str(e)}, status=status.HTTP_404_NOT_FOUND)
+
+    def delete(self, request: Request, recruitment_id: int) -> Response:
+        service = BookmarkService()
+        try:
+            service.remove(user=cast(User, request.user), recruitment_id=recruitment_id)
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        except NotFound as e:
+            return Response({"detail": str(e)}, status=status.HTTP_404_NOT_FOUND)
+
+
+class MyBookmarkedRecruitmentListView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request: Request) -> Response:
+        service = BookmarkService()
+        queryset = service.get_bookmarked_list(user=cast(User, request.user))
+
+        paginator = DefaultCursorPagination()
+        paginated_queryset = paginator.paginate_queryset(queryset, request, view=self)
+
+        serializer = MyBookmarkedRecruitmentListSerializer(paginated_queryset, many=True)
+        paginated_data = cast(list[dict[str, Any]], serializer.data)
+        return paginator.get_paginated_response(paginated_data)


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #229 
- 작업 요약: 사용자가 관심 있는 스터디 구인 공고를 저장(북마크)하고, 마이페이지 등 별도의 페이지에서 북마크한 공고 목록을 모아볼 수 있는 기능입니다. 사용자는 공고 목록 또는 상세 페이지에서 북마크를 추가하거나 취소할 수 있습니다.

## 📄 상세 내용
- [ ] 북마크 추가/삭제 및 목록 조회 API 구현 (REQ-RECM-010, REQ-RECM-011)
- [ ] 아키텍처 및 코드 품질 개선
- [ ] 테스트 및 안정성 확보

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
