### PR TITLE
Feature/celery task

### DIFF
--- a/apps/users/tasks.py
+++ b/apps/users/tasks.py
@@ -1,17 +1,18 @@
 import logging
-from celery import shared_task
 from datetime import date
-from django.db import transaction
+
+from celery import shared_task
 from django.contrib.auth import get_user_model
+from django.db import transaction
 
 from apps.users.models.withdrawals import Withdrawals
-from apps.users.models.user import User
 
 User = get_user_model()
-logger = logging.getLogger(__name__) # 테스크의 파일 로거 생성
+logger = logging.getLogger(__name__)  # 테스크의 파일 로거 생성
+
 
 @shared_task
-def delete_expired_withdrawals_users():
+def delete_expired_withdrawals_users() -> None:
     """
     탈퇴 유예 기간(due_date)이 지난 사용자 계정을 영구 삭제
     """
@@ -30,11 +31,12 @@ def delete_expired_withdrawals_users():
                     if user_to_delete:
                         user_email = user_to_delete.email
                         user_to_delete.delete()
-                        logger.info(f"사용자 계정 삭제: {user_email}") # info 레벨로 성공 로그
+                        logger.info(f"사용자 계정 삭제: {user_email}")  # info 레벨로 성공 로그
                 except User.DoesNotExist:
                     logger.warning(f"이미 삭제되었거나 존재하지 않는 사용자입니다. (탈퇴 요청 ID: {withdrawal.id})")
                 except Exception as e:
-                    logger.error(f"사용자 계정 삭제 중 오류 발생 (탈퇴 요청 ID: {withdrawal.id}, 오류: {e})", exc_info=True)
+                    logger.error(
+                        f"사용자 계정 삭제 중 오류 발생 (탈퇴 요청 ID: {withdrawal.id}, 오류: {e})", exc_info=True
+                    )
     else:
-        logger.info("만료된 탈퇴 요청이 없습니다") # 정상적인 상황 기록
-
+        logger.info("만료된 탈퇴 요청이 없습니다")  # 정상적인 상황 기록

--- a/apps/users/tasks.py
+++ b/apps/users/tasks.py
@@ -1,0 +1,40 @@
+import logging
+from celery import shared_task
+from datetime import date
+from django.db import transaction
+from django.contrib.auth import get_user_model
+
+from apps.users.models.withdrawals import Withdrawals
+from apps.users.models.user import User
+
+User = get_user_model()
+logger = logging.getLogger(__name__) # 테스크의 파일 로거 생성
+
+@shared_task
+def delete_expired_withdrawals_users():
+    """
+    탈퇴 유예 기간(due_date)이 지난 사용자 계정을 영구 삭제
+    """
+    # 오늘 날짜
+    today = date.today()
+
+    # due_date가 오늘이거나 오늘보다 이전인 객체 핉터링
+    expired_withdrawals = Withdrawals.objects.filter(due_date__lte=today, user__isnull=False)
+
+    if expired_withdrawals.exists():
+        with transaction.atomic():
+            for withdrawal in expired_withdrawals:
+                # 사용자 객체 삭제 기록은 유지
+                try:
+                    user_to_delete = withdrawal.user
+                    if user_to_delete:
+                        user_email = user_to_delete.email
+                        user_to_delete.delete()
+                        logger.info(f"사용자 계정 삭제: {user_email}") # info 레벨로 성공 로그
+                except User.DoesNotExist:
+                    logger.warning(f"이미 삭제되었거나 존재하지 않는 사용자입니다. (탈퇴 요청 ID: {withdrawal.id})")
+                except Exception as e:
+                    logger.error(f"사용자 계정 삭제 중 오류 발생 (탈퇴 요청 ID: {withdrawal.id}, 오류: {e})", exc_info=True)
+    else:
+        logger.info("만료된 탈퇴 요청이 없습니다") # 정상적인 상황 기록
+

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -259,4 +259,8 @@ CELERY_BEAT_SCHEDULE = {
         "task": "apps.notifications.tasks.notify_upcoming_schedules",
         "schedule": crontab(hour=0, minute=1),
     },
+    'delete_expired_withdrawals_users': {
+        'task': 'apps.users.tasks.delete_expired_withdrawals_users', # 테스크 경로
+        'schedule': crontab(hour=0, minute=10), # 매일 0시 15뷴 실행 (자정이후)
+    }
 }

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -259,8 +259,8 @@ CELERY_BEAT_SCHEDULE = {
         "task": "apps.notifications.tasks.notify_upcoming_schedules",
         "schedule": crontab(hour=0, minute=1),
     },
-    'delete_expired_withdrawals_users': {
-        'task': 'apps.users.tasks.delete_expired_withdrawals_users', # 테스크 경로
-        'schedule': crontab(hour=0, minute=10), # 매일 0시 15뷴 실행 (자정이후)
-    }
+    "delete_expired_withdrawals_users": {
+        "task": "apps.users.tasks.delete_expired_withdrawals_users",  # 테스크 경로
+        "schedule": crontab(hour=0, minute=10),  # 매일 0시 15뷴 실행 (자정이후)
+    },
 }


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #235 
- 작업 요약: 샐러리 테스크를 생성해서 탈퇴회원에서 유예기간지난 유저데이터만 삭제(기록은 남김)

## 📄 상세 내용
- [x] 테스크 생성해서 탈퇴회원 테이블에서 2주지난 유저 데이터 삭제
- [x] 세팅에 태스크 실행하도록 작성(0시 15분) 매일 자정 12시 15분마다 확인하고 삭제


## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
