### PR TITLE
Fix / 스터디 노트 업로드 API 스웨거 수정 및 이미지, 첨부파일 형식 수정

### DIFF
--- a/apps/study_notes/serializers/study_notes_serializers.py
+++ b/apps/study_notes/serializers/study_notes_serializers.py
@@ -65,6 +65,7 @@ class StudyNoteSerializer(serializers.ModelSerializer[StudyNote]):
             "updated_at",
         ]
         read_only_fields = ["id", "study_group", "ai_summary"]
+
     # 이미지 유효성 검사
     def validate_image_files(self, files: Sequence[UploadedFile]) -> Sequence[UploadedFile]:
         if len(files) > 5:
@@ -118,5 +119,3 @@ class StudyNoteUpdateSerializer(serializers.ModelSerializer[StudyNote]):
 class StudyNoteUploadSerializer(serializers.Serializer[dict[str, Any]]):
     image_files = serializers.ListField(child=serializers.ImageField(), write_only=True, required=False)
     attachment_files = serializers.ListField(child=serializers.FileField(), write_only=True, required=False)
-
-

--- a/apps/study_notes/serializers/study_notes_serializers.py
+++ b/apps/study_notes/serializers/study_notes_serializers.py
@@ -65,7 +65,6 @@ class StudyNoteSerializer(serializers.ModelSerializer[StudyNote]):
             "updated_at",
         ]
         read_only_fields = ["id", "study_group", "ai_summary"]
-
     # 이미지 유효성 검사
     def validate_image_files(self, files: Sequence[UploadedFile]) -> Sequence[UploadedFile]:
         if len(files) > 5:
@@ -115,6 +114,9 @@ class StudyNoteUpdateSerializer(serializers.ModelSerializer[StudyNote]):
         ]
 
 
+# 업로드용
 class StudyNoteUploadSerializer(serializers.Serializer[dict[str, Any]]):
     image_files = serializers.ListField(child=serializers.ImageField(), write_only=True, required=False)
     attachment_files = serializers.ListField(child=serializers.FileField(), write_only=True, required=False)
+
+

--- a/apps/study_notes/tests/test_study_notes_upload_file.py
+++ b/apps/study_notes/tests/test_study_notes_upload_file.py
@@ -35,38 +35,31 @@ class StudyNoteUploadViewTest(TestCase):
         self.study_group.members.add(self.user)
         self.client.force_authenticate(user=self.user)
 
-    def test_upload_success(self) -> None:
-        """업로드 API 정상 동작 테스트"""
+    def test_upload_multiple_files_no_loop(self) -> None:
+        """업로드 API - 반복문 없이 여러 파일 업로드 테스트"""
+
         from django.urls import reverse
 
-        url = reverse("upload-study-note-files", kwargs={"group_uuid": str(self.study_group.uuid)})
+        url = reverse("upload-study-note-files")
 
-        image_file = create_temp_image()
-        attachment_file = SimpleUploadedFile("test.txt", b"hello world", content_type="text/plain")
-        data = {"images_file": [image_file], "attachments_file": [attachment_file]}
+        # 이미지 3개 생성
+        image_file1 = create_temp_image()
+        image_file2 = create_temp_image()
+        image_file3 = create_temp_image()
 
-        response = cast(Response, self.client.post(url, data, format="multipart"))
-        self.assertEqual(response.status_code, 200)
-        self.assertIn("images", response.data)
-        self.assertIn("attachments", response.data)
-        self.assertEqual(len(response.data["images"]), 1)
-        self.assertEqual(len(response.data["attachments"]), 1)
+        # 첨부파일 3개 생성
+        attachment_file1 = SimpleUploadedFile("test1.txt", b"hello world", content_type="text/plain")
+        attachment_file2 = SimpleUploadedFile("test2.txt", b"hello world", content_type="text/plain")
+        attachment_file3 = SimpleUploadedFile("test3.txt", b"hello world", content_type="text/plain")
 
-    def test_create_note_view_success(self) -> None:
-        """노트 생성 API 정상 동작 테스트"""
-        from django.urls import reverse
-
-        url = reverse("study-notes", kwargs={"group_uuid": str(self.study_group.uuid)})
-
-        image_file = create_temp_image()
-        attachment_file = SimpleUploadedFile("test.txt", b"hello world", content_type="text/plain")
         data = {
-            "title": "테스트 노트",
-            "content": "본문 내용",
-            "image_files": [image_file],
-            "attachment_files": [attachment_file],
+            "image_files": [image_file1, image_file2, image_file3],
+            "attachment_files": [attachment_file1, attachment_file2, attachment_file3],
         }
 
         response = cast(Response, self.client.post(url, data, format="multipart"))
-        self.assertIn(response.status_code, [200, 201])
-        self.assertEqual(response.data.get("title"), "테스트 노트")
+
+        # 검증
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data["images"]), 3)
+        self.assertEqual(len(response.data["attachments"]), 3)

--- a/apps/study_notes/urls/study_note_urls.py
+++ b/apps/study_notes/urls/study_note_urls.py
@@ -9,6 +9,6 @@ urlpatterns = [
     path("/<uuid:group_uuid>/notes", StudyNoteView.as_view(), name="study-notes"),
     # GET, PATCH /api/v1/study-notes/<group_uuid>/notes/<note_id> - 스터디 노트 상세 조회, 수정
     path("/<uuid:group_uuid>/notes/<int:note_id>", StudyNoteDetailView.as_view(), name="study-note-detail"),
-    # POST /api/v1/study-notes/<group_uuid>/upload - 이미지/첨부파일 업로드
-    path("/<uuid:group_uuid>/upload", StudyNoteUploadView.as_view(), name="upload-study-note-files"),
+    # POST /api/v1/study-notes/upload - 이미지/첨부파일 업로드
+    path("study-notes/upload", StudyNoteUploadView.as_view(), name="upload-study-note-files"),
 ]

--- a/apps/study_notes/views/study_notes_upload_view.py
+++ b/apps/study_notes/views/study_notes_upload_view.py
@@ -35,13 +35,13 @@ class StudyNoteUploadView(APIView):
         request=StudyNoteUploadSerializer,
         responses={200: {"type": "object"}},
     )
-    def post(self, request: Request, group_uuid: str) -> Response:
+    def post(self, request: Request) -> Response:
         service = self.get_service()
         assert service is not None
 
         files_to_upload = {
-            "images": request.FILES.getlist("images_file"),
-            "attachments": request.FILES.getlist("attachments_file"),
+            "images": request.FILES.getlist("image_files"),
+            "attachments": request.FILES.getlist("attachment_files"),
         }
 
         result: Dict[str, List[Union[str, Dict[str, str]]]] = {"images": [], "attachments": [], "failed": []}


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호:
- 작업 요약 : 스터디 노트 업로드 API 수정

## 📄 상세 내용
- [x] StudyNoteUploadView 필요없는 부분 제거
- [x] StudyNoteUploadSerializer 업로드 파일 전용 시리얼라이저 작성
- [x] urls.py 업로드 엔드포인트 경로 정리
- [x] 변경된 부분에 맞춰 테스트 코드 수정

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
