### PR TITLE
💡 chore : 스웨거에서 reason_detail이 안나와서 수정 및 메소드 수정

### DIFF
--- a/apps/users/tests/test_withdrawals.py
+++ b/apps/users/tests/test_withdrawals.py
@@ -29,7 +29,7 @@ class UserWithdrawalJWTAPITest(APITestCase, VerificationMixin):
             "reason": WithdrawalsReasonChoices.PRIVACY_CONCERNS,
             "reason_detail": "개인정보/보안/우려",
         }  # 요청 데이터
-        response = self.client.post(self.url, data)
+        response = self.client.delete(self.url, data)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -51,7 +51,7 @@ class UserWithdrawalJWTAPITest(APITestCase, VerificationMixin):
             "reason": WithdrawalsReasonChoices.PRIVACY_CONCERNS,
             "reason_detail": "첫 요청",
         }
-        first_response = self.client.post(self.url, first_data)
+        first_response = self.client.delete(self.url, first_data)
         self.assertEqual(first_response.status_code, status.HTTP_200_OK)
 
         # 두 번째 중복 요청(비정상적)
@@ -59,7 +59,7 @@ class UserWithdrawalJWTAPITest(APITestCase, VerificationMixin):
             "reason": WithdrawalsReasonChoices.PRIVACY_CONCERNS,
             "reason_detail": "테스트용 중복 요청",
         }
-        second_response = self.client.post(self.url, second_data)
+        second_response = self.client.delete(self.url, second_data)
         self.assertEqual(second_response.status_code, status.HTTP_400_BAD_REQUEST)
 
         self.assertIn("error", second_response.data)

--- a/apps/users/views/withdrawals_view.py
+++ b/apps/users/views/withdrawals_view.py
@@ -42,13 +42,13 @@ class WithdrawalAPIView(APIView):
         examples=[
             OpenApiExample(
                 "계정 탈퇴 요청 예시",
-                value={"reason": "서비스 불만족"},
+                value={"reason": "서비스 불만족", "reason_detail": "탈퇴 요청 구체적인 사유"},
                 request_only=True,
             ),
         ],
     )
-    def post(self, request: Request) -> Response:
-        assert request.user.is_authenticated  # mypy 오류로 인한 검증 코드
+    def delete(self, request: Request) -> Response:
+
         request_serializer = WithdrawalRequestSerializer(data=request.data, context={"request": request})
         request_serializer.is_valid(raise_exception=True)
 


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #257 
- 작업 요약: 회원탈퇴 뷰 수정

## 📄 상세 내용
- [x]스웨거에서 reason_detail 입력칸이안나와서 나오게수정 
- [x] http 매서드 post -> delete 수정
- [ ] 주요 변경 사항 3

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
