### PR TITLE
로그인시 듀데이트 반환하도록 수정 및 상황별 에러메시지 수정

### DIFF
--- a/apps/users/services/auth_service.py
+++ b/apps/users/services/auth_service.py
@@ -15,8 +15,23 @@ class AuthService:
 
     @staticmethod
     def email_login(email: str, password: str) -> tuple[User, dict[str, str]]:
-        user: Union[User, None] = authenticate(email=email, password=password)
+        # 유저 조회
+        try:
+            user = User.objects.get(email=email)
+        except User.DoesNotExist:
+            user = None
 
+        # is_active 체크
+        if user and not user.is_active:
+            withdrawal = getattr(user, "withdrawal", None)
+            raise AuthenticationFailed(
+                detail={
+                    "detail": "탈퇴 계정입니다. 복구 가능 기간 확인 바랍니다.",
+                    "due_date": withdrawal.due_date if withdrawal else None,
+                }
+            )
+        # 비밀번호 인증
+        user: Union[User, None] = authenticate(email=email, password=password)
         if user is None:
             raise AuthenticationFailed("이메일 또는 비밀번호가 틀립니다")
 

--- a/apps/users/services/auth_service.py
+++ b/apps/users/services/auth_service.py
@@ -35,8 +35,8 @@ class AuthService:
             else:
                 raise AuthenticationFailed("탈퇴계정, 비밀번호가 틀립니다")
 
-        user_obj: Union[User, None] = authenticate(email=email, password=password)
-        if user is None:
+        authenticate_user = authenticate(email=email, password=password)
+        if authenticate_user is None:
             raise AuthenticationFailed("정상계정, 비밀번호가 틀립니다")
 
         refresh = RefreshToken.for_user(user)

--- a/apps/users/services/auth_service.py
+++ b/apps/users/services/auth_service.py
@@ -22,7 +22,6 @@ class AuthService:
         except User.DoesNotExist:
             raise AuthenticationFailed("존재하지 않는 이메일입니다")
 
-
         # is_active 체크 및 비밀번호 검증
         if user and not user.is_active:
             if check_password(password, user.password):

--- a/apps/users/services/auth_service.py
+++ b/apps/users/services/auth_service.py
@@ -1,6 +1,7 @@
 from typing import Optional, Union, cast
 
 from django.contrib.auth import authenticate
+from django.contrib.auth.hashers import check_password
 from rest_framework.exceptions import AuthenticationFailed, ValidationError
 from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.tokens import RefreshToken, Token
@@ -19,21 +20,25 @@ class AuthService:
         try:
             user = User.objects.get(email=email)
         except User.DoesNotExist:
-            user = None
+            raise AuthenticationFailed("존재하지 않는 이메일입니다")
 
-        # is_active 체크
+
+        # is_active 체크 및 비밀번호 검증
         if user and not user.is_active:
-            withdrawal = getattr(user, "withdrawal", None)
-            raise AuthenticationFailed(
-                detail={
-                    "detail": "탈퇴 계정입니다. 복구 가능 기간 확인 바랍니다.",
-                    "due_date": withdrawal.due_date if withdrawal else None,
-                }
-            )
-        # 비밀번호 인증
-        user = authenticate(email=email, password=password)
+            if check_password(password, user.password):
+                withdrawal = getattr(user, "withdrawal", None)
+                raise AuthenticationFailed(
+                    detail={
+                        "detail": "탈퇴 계정입니다. 복구 가능 기간 확인 바랍니다.",
+                        "due_date": withdrawal.due_date if withdrawal else None,
+                    }
+                )
+            else:
+                raise AuthenticationFailed("탈퇴계정, 비밀번호가 틀립니다")
+
+        user_obj: Union[User, None] = authenticate(email=email, password=password)
         if user is None:
-            raise AuthenticationFailed("이메일 또는 비밀번호가 틀립니다")
+            raise AuthenticationFailed("정상계정, 비밀번호가 틀립니다")
 
         refresh = RefreshToken.for_user(user)
         access_token = str(refresh.access_token)

--- a/apps/users/services/auth_service.py
+++ b/apps/users/services/auth_service.py
@@ -31,7 +31,7 @@ class AuthService:
                 }
             )
         # 비밀번호 인증
-        user: Union[User, None] = authenticate(email=email, password=password)
+        user = authenticate(email=email, password=password)
         if user is None:
             raise AuthenticationFailed("이메일 또는 비밀번호가 틀립니다")
 

--- a/apps/users/tests/test_auth_token.py
+++ b/apps/users/tests/test_auth_token.py
@@ -31,7 +31,7 @@ class AuthTokenViewsTests(APITestCase, VerificationMixin):
         """
         로그인 실패 케이스
         """
-        response = self.client.post(self.login_url, {"email": self.email, "password": "wrongpassword"})
+        response = self.client.post(self.login_url, {"email": self.email, "password": "wrossngpassword1"})
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertIn("error", response.data)

--- a/apps/users/views/auth_view.py
+++ b/apps/users/views/auth_view.py
@@ -71,26 +71,18 @@ class EmailLoginAPIView(APIView):
         try:
             user, tokens = AuthService.email_login(**serializer.validated_data)
         except AuthenticationFailed as e:
-            return Response({"error": str(e)}, status=status.HTTP_401_UNAUTHORIZED)
+            if isinstance(e.detail, dict):
+                return Response({"error": e.detail}, status=status.HTTP_401_UNAUTHORIZED)
+            return Response({"error": str(e.detail)}, status=status.HTTP_401_UNAUTHORIZED)
 
         # 로그인 분기 처리
 
-        if user.is_active:
-            response = Response({"access": tokens["access"]}, status=status.HTTP_200_OK)
-            response.set_cookie(
-                "refresh", tokens["refresh"], httponly=True, domain=".ozcoding.site", secure=True, samesite="None"
-            )
-            return response
+        response = Response({"access": tokens["access"]}, status=status.HTTP_200_OK)
+        response.set_cookie(
+            "refresh", tokens["refresh"], httponly=True, domain=".ozcoding.site", secure=True, samesite="None"
+        )
 
-        else:
-            withdrawal = getattr(user, "withdrawal", None)
-            return Response(
-                {
-                    "detail": "탈퇴 계정입니다. 복구 가능 기간 확인 바랍니다.",
-                    "due_date": withdrawal.due_date if withdrawal else None,
-                },
-                status=status.HTTP_401_UNAUTHORIZED,
-            )
+        return response
 
 
 class LogoutAPIView(APIView):


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #259 
- 작업 요약: 탈퇴회원이 로그인시 듀데이트 반환

## 📄 상세 내용
- [x] 로그인 뷰에서 듀데이트반환하게 되있는데 서비스코드의 순서떄문에 반환이안되서 반환되도록 수정

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
