### PR TITLE
Feature/login refactor

### DIFF
--- a/apps/core/tests/mixins/test_user_mixins.py
+++ b/apps/core/tests/mixins/test_user_mixins.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.test import SimpleTestCase, override_settings
 from django.urls import reverse
 
+from apps.users.models import Withdrawals
 from apps.users.models.user import User
 from apps.users.services.email_service import EmailVerificationService
 from apps.users.services.phone_service import PhoneVerificationService
@@ -92,3 +93,5 @@ class VerificationMixin(TestUserMixin, IsolatedCacheTestMixin):
     revoke_url: ClassVar[str]
     email_service: ClassVar[EmailVerificationService]
     phone_service: ClassVar[PhoneVerificationService]
+    withdrawal: ClassVar[Withdrawals]
+    login_user: ClassVar[str]

--- a/apps/users/services/auth_service.py
+++ b/apps/users/services/auth_service.py
@@ -6,7 +6,7 @@ from rest_framework.exceptions import AuthenticationFailed, ValidationError
 from rest_framework_simplejwt.exceptions import TokenError
 from rest_framework_simplejwt.tokens import RefreshToken, Token
 
-from apps.users.models import User
+from apps.users.models import User, Withdrawals
 
 
 class AuthService:
@@ -25,11 +25,11 @@ class AuthService:
         # is_active 체크 및 비밀번호 검증
         if user and not user.is_active:
             if check_password(password, user.password):
-                withdrawal = getattr(user, "withdrawal", None)
+                withdrawal = Withdrawals.objects.filter(user=user).first()
                 raise AuthenticationFailed(
                     detail={
                         "detail": "탈퇴 계정입니다. 복구 가능 기간 확인 바랍니다.",
-                        "due_date": withdrawal.due_date if withdrawal else None,
+                        "due_date": withdrawal.due_date.isoformat() if withdrawal else None,
                     }
                 )
             else:

--- a/apps/users/services/auth_service.py
+++ b/apps/users/services/auth_service.py
@@ -23,7 +23,7 @@ class AuthService:
             raise AuthenticationFailed("존재하지 않는 이메일입니다")
 
         # is_active 체크 및 비밀번호 검증
-        if user and not user.is_active:
+        if not user.is_active:
             if check_password(password, user.password):
                 withdrawal = Withdrawals.objects.filter(user=user).first()
                 raise AuthenticationFailed(

--- a/apps/users/tests/test_auth_token.py
+++ b/apps/users/tests/test_auth_token.py
@@ -7,7 +7,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from apps.core.tests.mixins.test_user_mixins import VerificationMixin
-from apps.users.models import Withdrawals, User
+from apps.users.models import User, Withdrawals
 
 
 class AuthTokenViewsTests(APITestCase, VerificationMixin):
@@ -100,6 +100,7 @@ class AuthTokenViewsTests(APITestCase, VerificationMixin):
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertIn("리프레시 토큰이 유효하지 않습니다", response.data["error"])
 
+
 class InactiveUserLoginTestCase(APITestCase, VerificationMixin):
 
     @classmethod
@@ -110,19 +111,15 @@ class InactiveUserLoginTestCase(APITestCase, VerificationMixin):
             email="inactive@example.com",
             password="testpassword",
             is_active=False,  # 탈퇴 상태
-
-            name= "테스트유저",
-            nickname= "tester",
-            phone_number= "01012345678",
-            gender= "M",
-            birthday= "2000-01-01",
-            )
+            name="테스트유저",
+            nickname="tester",
+            phone_number="01012345678",
+            gender="M",
+            birthday="2000-01-01",
+        )
 
         # 2) 탈퇴 요청 생성 + due_date 지정
-        cls.withdrawal = Withdrawals.objects.create(
-            user=cls.user,
-            due_date=date.today() + timedelta(days=14)
-        )
+        cls.withdrawal = Withdrawals.objects.create(user=cls.user, due_date=date.today() + timedelta(days=14))
 
         cls.login_url = reverse("email_login")
 
@@ -131,9 +128,7 @@ class InactiveUserLoginTestCase(APITestCase, VerificationMixin):
         탈퇴 계정 로그인 시 due_date가 반환되는지 확인
         """
         response = self.client.post(
-            self.login_url,
-            {"email": self.user.email, "password": "testpassword"},
-            format="json"
+            self.login_url, {"email": self.user.email, "password": "testpassword"}, format="json"
         )
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
@@ -143,13 +138,7 @@ class InactiveUserLoginTestCase(APITestCase, VerificationMixin):
         error_detail = response.data["error"]
         self.assertIsInstance(error_detail, dict)
         self.assertIn("due_date", error_detail)
-        self.assertEqual(
-            error_detail["due_date"],
-            self.withdrawal.due_date.isoformat()
-        )
+        self.assertEqual(error_detail["due_date"], self.withdrawal.due_date.isoformat())
 
         self.assertIn("detail", error_detail)
-        self.assertEqual(
-            error_detail["detail"],
-            "탈퇴 계정입니다. 복구 가능 기간 확인 바랍니다."
-        )
+        self.assertEqual(error_detail["detail"], "탈퇴 계정입니다. 복구 가능 기간 확인 바랍니다.")

--- a/apps/users/tests/test_auth_token.py
+++ b/apps/users/tests/test_auth_token.py
@@ -1,3 +1,4 @@
+from datetime import date, timedelta
 from http.cookies import Morsel
 from typing import cast
 
@@ -6,6 +7,7 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 from apps.core.tests.mixins.test_user_mixins import VerificationMixin
+from apps.users.models import Withdrawals, User
 
 
 class AuthTokenViewsTests(APITestCase, VerificationMixin):
@@ -97,3 +99,57 @@ class AuthTokenViewsTests(APITestCase, VerificationMixin):
         response = self.client.post(self.revoke_url)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertIn("리프레시 토큰이 유효하지 않습니다", response.data["error"])
+
+class InactiveUserLoginTestCase(APITestCase, VerificationMixin):
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+
+        # 1) 탈퇴 계정 생성
+        cls.user = User.objects.create_user(
+            email="inactive@example.com",
+            password="testpassword",
+            is_active=False,  # 탈퇴 상태
+
+            name= "테스트유저",
+            nickname= "tester",
+            phone_number= "01012345678",
+            gender= "M",
+            birthday= "2000-01-01",
+            )
+
+        # 2) 탈퇴 요청 생성 + due_date 지정
+        cls.withdrawal = Withdrawals.objects.create(
+            user=cls.user,
+            due_date=date.today() + timedelta(days=14)
+        )
+
+        cls.login_url = reverse("email_login")
+
+    def test_inactive_user_login_due_date(self) -> None:
+        """
+        탈퇴 계정 로그인 시 due_date가 반환되는지 확인
+        """
+        response = self.client.post(
+            self.login_url,
+            {"email": self.user.email, "password": "testpassword"},
+            format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn("error", response.data)
+
+        # error가 dict 형태인지 확인 후 due_date 검증
+        error_detail = response.data["error"]
+        self.assertIsInstance(error_detail, dict)
+        self.assertIn("due_date", error_detail)
+        self.assertEqual(
+            error_detail["due_date"],
+            self.withdrawal.due_date.isoformat()
+        )
+
+        self.assertIn("detail", error_detail)
+        self.assertEqual(
+            error_detail["detail"],
+            "탈퇴 계정입니다. 복구 가능 기간 확인 바랍니다."
+        )


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #263 
- 작업 요약: 서비스에서 듀데이트 인식 못하던거 인식하도록 수정

## 📄 상세 내용
- [x] 서비스 코드에서 ORM으로 탈퇴 계정의 due_date를 올바르게 조회하도록 수정.
- [x] 조회된 due_date는 Python date 객체이므로, JSON 응답 시 문자열로 변환되도록 isoformat() 메서드 적용.

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
