### PR TITLE
🐛 fix: 알림 그룹 채팅방 url 변경

### DIFF
--- a/apps/notifications/const.py
+++ b/apps/notifications/const.py
@@ -5,7 +5,7 @@ from apps.notifications.models import Notification
 # 알림 타입별 기본 URL 패턴
 BACK_URL_LINK_BY_NOTIFICATION_TYPE: Dict[Notification.NotificationType, str] = {
     Notification.NotificationType.STUDY_REVIEW_REQUEST: "/my-page/completed-study",
-    Notification.NotificationType.STUDY_JOIN: "/study-group/{group_id}/chat",
+    Notification.NotificationType.STUDY_JOIN: "/study-group/{group_uuid}/chat",
     Notification.NotificationType.STUDY_NOTE_CREATE: "/study-group/{group_id}",
     Notification.NotificationType.APPLICATION_ACCEPT: "/my-page/applications",
     Notification.NotificationType.APPLICATION_REJECT: "/my-page/applications",

--- a/apps/notifications/services/noti_create_service.py
+++ b/apps/notifications/services/noti_create_service.py
@@ -91,7 +91,7 @@ class ApplicationNotificationService:
                 user_id=uid,
                 content=f"{group.name}에 {new_user.nickname} 님이 참여했습니다. 환영해주세요!",
                 notification_type=Notification.NotificationType.STUDY_JOIN,
-                back_url_link=get_notification_back_url(Notification.NotificationType.STUDY_JOIN, group_id=group.id),
+                back_url_link=get_notification_back_url(Notification.NotificationType.STUDY_JOIN, group_uuid=group.uuid),
             )
             for uid in accepted_user_ids
         ]

--- a/apps/notifications/services/noti_create_service.py
+++ b/apps/notifications/services/noti_create_service.py
@@ -91,7 +91,9 @@ class ApplicationNotificationService:
                 user_id=uid,
                 content=f"{group.name}에 {new_user.nickname} 님이 참여했습니다. 환영해주세요!",
                 notification_type=Notification.NotificationType.STUDY_JOIN,
-                back_url_link=get_notification_back_url(Notification.NotificationType.STUDY_JOIN, group_uuid=group.uuid),
+                back_url_link=get_notification_back_url(
+                    Notification.NotificationType.STUDY_JOIN, group_uuid=group.uuid
+                ),
             )
             for uid in accepted_user_ids
         ]

--- a/apps/notifications/tests/test_notify_application.py
+++ b/apps/notifications/tests/test_notify_application.py
@@ -231,5 +231,5 @@ class NotificationOnApplicationCreateTests(TransactionTestCase):
         assert n_old is not None  # mypy
         self.assertIn(self.recruitment.study_group.name, n_old.content)
         self.assertIn(self.applicant.nickname, n_old.content)
-        group_id = self.recruitment.study_group_id
-        self.assertEqual(n_old.back_url_link, f"/study-group/{group_id}/chat")
+        group_uuid = self.recruitment.study_group.uuid
+        self.assertEqual(n_old.back_url_link, f"/study-group/{group_uuid}/chat")


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: 
- 작업 요약: 알림 그룹 채팅방 url 변경

## 📄 상세 내용
- [x] id -> uuid로 변경

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
