### PR TITLE
Feature/recruitment admin delete

### DIFF
--- a/apps/recruitments/tests/test_admin_recruitments_detail.py
+++ b/apps/recruitments/tests/test_admin_recruitments_detail.py
@@ -123,3 +123,25 @@ class AdminRecruitmentDetailViewTest(APITestCase):
         data = response.data
         expected = sum(lecture.discount_price for lecture in self.study_group.lectures.all())
         self.assertEqual(data["expected_payment_cost"], expected)
+
+    # delete
+    def test_delete_recruitment_as_admin_success(self) -> None:
+        self.client.force_authenticate(user=self.admin_user)
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(RecruitmentAttachment.objects.filter(id=self.recruitment.id).exists())
+
+    def test_delete_recruitment_not_found(self) -> None:
+        self.client.force_authenticate(user=self.admin_user)
+        not_found_url = reverse("admin-recruitment-detail", kwargs={"recruitment_id": 9999})
+        response = self.client.delete(not_found_url)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_delete_recruitment_permission_denied_for_non_admin(self) -> None:
+        self.client.force_authenticate(user=self.regular_user1)
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_delete_recruitment_unauthenticated(self) -> None:
+        response = self.client.delete(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/apps/recruitments/tests/test_admin_recruitments_detail.py
+++ b/apps/recruitments/tests/test_admin_recruitments_detail.py
@@ -124,7 +124,7 @@ class AdminRecruitmentDetailViewTest(APITestCase):
         expected = sum(lecture.discount_price for lecture in self.study_group.lectures.all())
         self.assertEqual(data["expected_payment_cost"], expected)
 
-    # delete
+    # 삭제
     def test_delete_recruitment_as_admin_success(self) -> None:
         self.client.force_authenticate(user=self.admin_user)
         response = self.client.delete(self.url)

--- a/apps/recruitments/views/admin_recruitments_views.py
+++ b/apps/recruitments/views/admin_recruitments_views.py
@@ -39,6 +39,7 @@ class AdminRecruitmentDetailView(APIView):
         serializer = AdminRecruitmentDetailSerializer(recruitment)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+    # 삭제
     def delete(self, request: Request, recruitment_id: int) -> Response:
         try:
             recruitment = Recruitment.objects.get(id=recruitment_id)

--- a/apps/recruitments/views/admin_recruitments_views.py
+++ b/apps/recruitments/views/admin_recruitments_views.py
@@ -38,3 +38,12 @@ class AdminRecruitmentDetailView(APIView):
         recruitment = get_recruitment_detail_for_admin(recruitment_id=recruitment_id)
         serializer = AdminRecruitmentDetailSerializer(recruitment)
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def delete(self, request: Request, recruitment_id: int) -> Response:
+        try:
+            recruitment = Recruitment.objects.get(id=recruitment_id)
+        except Recruitment.DoesNotExist:
+            return Response({"detail": "Recruitment not found"}, status=status.HTTP_404_NOT_FOUND)
+
+        recruitment.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #267 
- 작업 요약: 어드민이 공고를 삭제할 수 있음

## 📄 상세 내용
- [ ] 작성자 뿐만 아니라, 어드민 또한 공고를 삭제할 수 있음
- [ ] 삭제 시, 해당 공고에 지원한 내역들도 함께 데이터베이스에서 삭제되어야 함

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
