### PR TITLE
✨ feat: 로그인 사용자 용 sse 엔드포인트 추가

### DIFF
--- a/apps/notifications/views.py
+++ b/apps/notifications/views.py
@@ -1,6 +1,9 @@
 from typing import Any, cast
 
+from django.contrib.auth.decorators import login_required
 from django.db.models import QuerySet
+from django.http import HttpRequest, StreamingHttpResponse
+from django_eventstream.views import events  # type: ignore[import-untyped]
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.generics import ListAPIView
@@ -113,3 +116,9 @@ class UnreadCountView(APIView):
         payload: UnreadCountOut = {"unread_count": count}
         serializer = UnreadCountSerializer(instance=payload)
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+@login_required
+def events_me(request: HttpRequest) -> StreamingHttpResponse:
+    # 로그인된 유저의 개인 채널로 바로 구독
+    return cast(StreamingHttpResponse, events(request, channels=[f"user-{request.user.id}"]))

--- a/config/urls.py
+++ b/config/urls.py
@@ -8,6 +8,8 @@ from drf_spectacular.views import (
     SpectacularSwaggerView,
 )
 
+from apps.notifications.views import events_me
+
 urlpatterns: list[URLPattern | URLResolver] = [
     path("api/v1/", include("apps.users.urls")),
     path("api/v1/admin/", include("apps.users.urls.admin_urls")),
@@ -23,6 +25,7 @@ urlpatterns: list[URLPattern | URLResolver] = [
     path("api/v1/study-notes", include("apps.study_notes.urls.study_note_urls")),
     path("api/v1/applications", include("apps.applications.urls")),
     path("api/v1/chat", include("apps.chat.urls")),
+    path("events/me", events_me, name="events-me"),
     path("events/", include("django_eventstream.urls")),
 ]
 


### PR DESCRIPTION

## ✅ PR 요약
- 관련 이슈 번호: 
- 작업 요약: 로그인 사용자 용 sse 엔드포인트 추가

## 📄 상세 내용
- [x] 로그인 사용자의 user-<id> 채널을 자동 세팅하여 eventstream 위임

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
