### PR TITLE
[Fix/user-info] Swagger 대응 @extend_schema 수정

### DIFF
--- a/apps/users/views/user_info_view.py
+++ b/apps/users/views/user_info_view.py
@@ -109,7 +109,6 @@ class UserInfoView(AuthenticatedAPIview):
             name="여러 항목 동시 수정",
             value={
                 "nickname": "upuser",
-                "password": "strongpw-123",
                 "phone_number": "01011112222",
                 "verification_code": "112233",
             },


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #203 
- 작업 요약: 프론트엔드에서 Swagger 양식과 맞지 않는다는 현상 수정

## 📄 상세 내용
- [x] `apps/users/views/user_info_view.py`에서 OpenApiExample 양식 수정

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다(버그 수정/기능에 대한 테스트).
